### PR TITLE
fix: "schemaPatcher" to patch deeply nested props

### DIFF
--- a/.changeset/honest-mayflies-occur.md
+++ b/.changeset/honest-mayflies-occur.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-json-schema': patch
+---
+
+Fix `schemaPatcher` to patch deeply nested props

--- a/src/utils/patchJsonSchema.ts
+++ b/src/utils/patchJsonSchema.ts
@@ -7,6 +7,7 @@ export function patchJsonSchema(
 ): JSONSchema {
   if (schema && schemaPatcher) {
     traverse(schema, {
+      allKeys: true,
       cb: (schema) => {
         schemaPatcher({ schema });
       },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -19,7 +19,7 @@ describe('openapiToTsJsonSchema', async () => {
     );
 
     const januarySchema = await importFresh(
-      path.resolve(outputFolder, 'components.months/January.ts'),
+      path.resolve(outputFolder, 'components.months/January'),
     );
     const februarySchema = await importFresh(
       path.resolve(outputFolder, 'components.months/February'),

--- a/test/schemaPatcher.test.ts
+++ b/test/schemaPatcher.test.ts
@@ -8,8 +8,8 @@ const fixtures = path.resolve(__dirname, 'fixtures');
 describe('"schemaPatcher" option', () => {
   it('transforms generated JSON schemas', async () => {
     const { outputFolder } = await openapiToTsJsonSchema({
-      openApiSchema: path.resolve(fixtures, 'mini-referenced/specs.yaml'),
-      definitionPathsToGenerateFrom: ['components.months'],
+      openApiSchema: path.resolve(fixtures, 'complex/specs.yaml'),
+      definitionPathsToGenerateFrom: ['components.months', 'paths'],
       schemaPatcher: ({ schema }) => {
         if (schema.description === 'January description') {
           schema.description = 'Patched January description';
@@ -30,5 +30,15 @@ describe('"schemaPatcher" option', () => {
         isJanuary: { type: ['string', 'null'], enum: ['yes', 'no', null] },
       },
     });
+
+    // Testing deep nested props being patched, too
+    const pathSchema = await importFresh(
+      path.resolve(outputFolder, 'paths/v1|path-1'),
+    );
+
+    expect(
+      pathSchema.default.get.responses[200].content['application/json'].schema
+        .oneOf[0].description,
+    ).toBe('Patched January description');
   });
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

`schemaPatcher` patching only 1 level nested props

## What is the new behaviour?

Traverse all output objects props

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
