### PR TITLE
refactor: convert openApi parameter only in expected paths

### DIFF
--- a/.changeset/clean-eels-visit.md
+++ b/.changeset/clean-eels-visit.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-json-schema': minor
+---
+
+OpenAPI parameters get converted only when found in the places dictated by the specs (`paths[path].parameters` and `paths[path][operation].parameters`)

--- a/src/utils/convertOpenApiToJsonSchema.ts
+++ b/src/utils/convertOpenApiToJsonSchema.ts
@@ -1,5 +1,5 @@
 import { fromSchema } from '@openapi-contrib/openapi-schema-to-json-schema';
-import type { OpenApiSchema } from '.';
+import { OpenApiSchema, convertOpenApiParameters } from '.';
 
 export function convertOpenApiToJsonSchema(schema: OpenApiSchema) {
   // Build a list of components dotted paths to convert
@@ -10,7 +10,9 @@ export function convertOpenApiToJsonSchema(schema: OpenApiSchema) {
     );
   }
 
-  return fromSchema(schema, {
+  const jsonSchema = fromSchema(schema, {
     definitionKeywords,
   });
+
+  return jsonSchema;
 }

--- a/src/utils/generateJsonSchemaFiles.ts
+++ b/src/utils/generateJsonSchemaFiles.ts
@@ -1,12 +1,7 @@
 import filenamify from 'filenamify';
 import fs from 'fs/promises';
 import path from 'path';
-import {
-  patchJsonSchema,
-  jsonSchemaToTsConst,
-  JSONSchema,
-  convertOpenApiParameters,
-} from './';
+import { patchJsonSchema, jsonSchemaToTsConst, JSONSchema } from './';
 
 export async function generateJsonSchemaFiles({
   schemas,
@@ -21,8 +16,6 @@ export async function generateJsonSchemaFiles({
     const schemaNamedEscaped = filenamify(schemaName, { replacement: '|' });
     const schema = schemas[schemaName];
     const patchedSchema = patchJsonSchema(schema, schemaPatcher);
-    convertOpenApiParameters(patchedSchema);
-
     const tsSchema = await jsonSchemaToTsConst(patchedSchema);
 
     await fs.mkdir(outputPath, { recursive: true });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor

## What is the current behaviour?

Definition tree traversed to find `parameters` object

## What is the new behaviour?

 `parameters` object only converted when found in the places described by OpenAPI specs

## Does this PR introduce a breaking change?

No. User should make sure they provide spec complain OpenAPI specs

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
