### PR TITLE
feat: preserve commented properties in defererened schemas

### DIFF
--- a/.changeset/pink-starfishes-notice.md
+++ b/.changeset/pink-starfishes-notice.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-json-schema': minor
+---
+
+Preserve commented `$ref` property in deferenced schemas

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ Generated JSON schema path names get escaped in order to be valid file system na
 
 ## Todo
 
-- Explore ability to import shared sub schemas
+- Explore ability to import dereferenced schemas instead of inlining
 - Consider merging "operation" and "path" parameters definition
+- Consider removing required `definitionPathsToGenerateFrom` option in favour of exporting the whole OpenAPI definitions based on the structure defined in specs
 
 [ci-badge]: https://github.com/toomuchdesign/openapi-ts-json-schema/actions/workflows/ci.yml/badge.svg
 [ci]: https://github.com/toomuchdesign/openapi-ts-json-schema/actions/workflows/ci.yml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "openapi-ts-json-schema",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openapi-ts-json-schema",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
+        "comment-json": "^4.2.3",
         "filenamify": "^4.3.0",
         "json-schema": "^0.4.0",
         "json-schema-traverse": "^1.0.0",
@@ -1608,6 +1609,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ=="
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -1944,6 +1950,21 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
+    "node_modules/comment-json": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.3.tgz",
+      "integrity": "sha512-SsxdiOf064DWoZLH799Ata6u7iV658A11PlWtZATDlXPpKGJnbJZ5Z24ybixAi+LUUqJ/GKowAejtC5GFUG7Tw==",
+      "dependencies": {
+        "array-timsort": "^1.0.3",
+        "core-util-is": "^1.0.3",
+        "esprima": "^4.0.1",
+        "has-own-prop": "^2.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1955,6 +1976,11 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -2312,7 +2338,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -2738,6 +2763,14 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/has-own-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
+      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-property-descriptors": {
@@ -4287,6 +4320,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^10.1.0",
     "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
+    "comment-json": "^4.2.3",
     "filenamify": "^4.3.0",
     "json-schema": "^0.4.0",
     "json-schema-traverse": "^1.0.0",

--- a/src/openapiToTsJsonSchema.ts
+++ b/src/openapiToTsJsonSchema.ts
@@ -52,6 +52,23 @@ export async function openapiToTsJsonSchema({
   // Replace $refs
   const dereferencedJsonSchema = await $RefParser.dereference(
     initialJsonSchema,
+    {
+      dereference: {
+        // @ts-expect-error onDereference seems not to be properly typed
+        onDereference: (path, value) => {
+          /**
+           * Add commented out $ref prop with:
+           * https://github.com/kaelzhang/node-comment-json
+           */
+          value[Symbol.for('before')] = [
+            {
+              type: 'LineComment',
+              value: ` $ref: "${path}"`,
+            },
+          ];
+        },
+      },
+    },
   );
   const jsonSchema = convertOpenApiParameters(dereferencedJsonSchema);
 

--- a/src/utils/convertOpenApiToJsonSchema.ts
+++ b/src/utils/convertOpenApiToJsonSchema.ts
@@ -1,5 +1,5 @@
 import { fromSchema } from '@openapi-contrib/openapi-schema-to-json-schema';
-import { OpenApiSchema, convertOpenApiParameters } from '.';
+import { OpenApiSchema } from '.';
 
 export function convertOpenApiToJsonSchema(schema: OpenApiSchema) {
   // Build a list of components dotted paths to convert

--- a/src/utils/jsonSchemaToTsConst.ts
+++ b/src/utils/jsonSchemaToTsConst.ts
@@ -1,8 +1,10 @@
 import prettier from 'prettier';
+import { stringify } from 'comment-json';
 
 export async function jsonSchemaToTsConst(schema: unknown): Promise<string> {
-  const tsSchema = `export default ` + JSON.stringify(schema) + 'as const';
-
+  // Stringify schema with "node-comment-json" to generate inline comments
+  const stringifiedSchema = stringify(schema, null, 2);
+  const tsSchema = `export default ` + stringifiedSchema + 'as const';
   const formattedSchema = await prettier.format(tsSchema, {
     parser: 'typescript',
   });

--- a/test/circularReference.test.ts
+++ b/test/circularReference.test.ts
@@ -6,30 +6,17 @@ import { openapiToTsJsonSchema } from '../src';
 const fixtures = path.resolve(__dirname, 'fixtures');
 
 describe('Circular reference', () => {
-  it.fails(
-    'Dereferences and transforms even from paths not marked for generation',
-    async () => {
-      const { outputPath } = await openapiToTsJsonSchema({
-        openApiSchema: path.resolve(fixtures, 'circular-reference/specs.yaml'),
-        definitionPathsToGenerateFrom: ['components.schemas'],
-        silent: true,
-      });
+  it.fails('Works', async () => {
+    const { outputPath } = await openapiToTsJsonSchema({
+      openApiSchema: path.resolve(fixtures, 'circular-reference/specs.yaml'),
+      definitionPathsToGenerateFrom: ['components.schemas'],
+      silent: true,
+    });
 
-      const januarySchema = await importFresh(
-        path.resolve(outputPath, 'components.schemas/January'),
-      );
+    const januarySchema = await importFresh(
+      path.resolve(outputPath, 'components.schemas/January'),
+    );
 
-      expect(januarySchema.default).toEqual({
-        description: 'January description',
-        type: 'object',
-        properties: {
-          isJanuary: { type: ['string', 'null'], enum: ['yes', 'no', null] },
-        },
-      });
-
-      const februarySchema = await importFresh(
-        path.resolve(outputPath, 'components.schemas/February'),
-      );
-    },
-  );
+    expect(januarySchema).toBeDefined();
+  });
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behaviour?

`$ref` properties getting replaced with schemas. Hard to tell whether are schema was originally declared inline or it was a reference to another declaration

## What is the new behaviour?

Add a commented `$ref` prop when a schema gets deferenced. This should help pointing deferenced objects back to their original definition.

## Does this PR introduce a breaking change?

No. Comments where chosen over adding an actual meta prop to have no runtime impact (and preseve schemas strictness).

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
