### PR TITLE
fix: schema relative import of sibling schemas

### DIFF
--- a/.changeset/eleven-laws-fix.md
+++ b/.changeset/eleven-laws-fix.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-json-schema': minor
+---
+
+Handle circular `$ref` values.

--- a/README.md
+++ b/README.md
@@ -60,13 +60,15 @@ type MyModel = FromSchema<typeof myModelSchema>;
 
 Generated JSON schema path names get escaped in order to be valid file system names.
 
+Circular `$ref`s can be technically resolved with `experimentalImportRefs` option. But TS will stop the type recursion and type the schema as `any`. See [relevant tests](https://github.com/toomuchdesign/openapi-ts-json-schema/blob/master/test/circularReference.test.ts).
+
 Take a look at the [Developer's notes](./docs/developer-notes.md) for a few more in-depth explanations.
 
 ## Todo
 
 - Consider merging "operation" and "path" parameters definition
 - Consider removing required `definitionPathsToGenerateFrom` option in favour of exporting the whole OpenAPI definitions based on the structure defined in specs
-- Handle circular references
+- Consider adding a way to keep specific `$ref` values in case of recursion
 
 [ci-badge]: https://github.com/toomuchdesign/openapi-ts-json-schema/actions/workflows/ci.yml/badge.svg
 [ci]: https://github.com/toomuchdesign/openapi-ts-json-schema/actions/workflows/ci.yml

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -20,3 +20,4 @@ export type {
   SchemaMetaInfoMap,
 } from './types';
 export { addSchemaToGenerationMap } from './addSchemaToGenerationMap';
+export { makeRelativePath } from './makeRelativePath';

--- a/src/utils/jsonSchemaToTsConst/replacePlaceholdersWithImportedSchemas.ts
+++ b/src/utils/jsonSchemaToTsConst/replacePlaceholdersWithImportedSchemas.ts
@@ -1,5 +1,10 @@
 import path from 'node:path';
-import { replacePlaceholdersWith, refToPath, SchemaMetaInfoMap } from '..';
+import {
+  replacePlaceholdersWith,
+  refToPath,
+  SchemaMetaInfoMap,
+  makeRelativePath,
+} from '..';
 
 /**
  * Replace Refs placeholders with imported schemas
@@ -29,13 +34,13 @@ export function replacePlaceholdersWithImportedSchemas({
       }
 
       // Evaluate schema relative path from current schema file
-      const importedSchemaRelativePath = path.relative(
-        schemaAbsoluteDirName,
-        path.resolve(
+      const importedSchemaRelativePath = makeRelativePath({
+        fromDirectory: schemaAbsoluteDirName,
+        to: path.resolve(
           importedSchema.schemaAbsoluteDirName,
           importedSchema.schemaName,
         ),
-      );
+      });
 
       const { schemaUniqueName } = importedSchema;
 

--- a/src/utils/makeRelativePath.ts
+++ b/src/utils/makeRelativePath.ts
@@ -1,0 +1,14 @@
+import path from 'path';
+
+/**
+ * Evaluate the relative path from/to the given absolute paths
+ */
+export function makeRelativePath({
+  fromDirectory,
+  to,
+}: {
+  fromDirectory: string;
+  to: string;
+}): string {
+  return './' + path.relative(fromDirectory, to);
+}

--- a/test/experimentalImportRefs.test.ts
+++ b/test/experimentalImportRefs.test.ts
@@ -83,8 +83,8 @@ describe('"experimentalImportRefs" option', () => {
       );
 
       const expectedPath1File = await formatTypeScript(`
-        import componentsMonthsFebruary from "../components/months/February";
-        import componentsMonthsJanuary from "../components/months/January";
+        import componentsMonthsFebruary from "./../components/months/February";
+        import componentsMonthsJanuary from "./../components/months/January";
 
         export default {
           get: {
@@ -124,7 +124,7 @@ describe('"experimentalImportRefs" option', () => {
     );
 
     const expectedJanuarySchemaFile = await formatTypeScript(`
-      import componentsSchemasAnswer from "../schemas/Answer";
+      import componentsSchemasAnswer from "./../schemas/Answer";
 
       export default {
         description: "January description",
@@ -146,7 +146,7 @@ describe('"experimentalImportRefs" option', () => {
     );
 
     const expectedFebruarySchemaFile = await formatTypeScript(`
-      import componentsSchemasAnswer from "../schemas/Answer";
+      import componentsSchemasAnswer from "./../schemas/Answer";
 
       export default {
         description: "February description",

--- a/test/unit/makeRelativePath.test.ts
+++ b/test/unit/makeRelativePath.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { makeRelativePath } from '../../src/utils';
+
+describe('makeRelativePath', () => {
+  it.each([
+    {
+      fromDirectory: '/data/orandea/test/aaa',
+      to: '/data/orandea/impl/bbb',
+      expected: './../../impl/bbb',
+    },
+    {
+      fromDirectory: '/data/orandea/test',
+      to: '/data/orandea/impl/bbb',
+      expected: './../impl/bbb',
+    },
+    {
+      fromDirectory: '/data/orandea/test',
+      to: '/data/orandea/test/bbb',
+      expected: './bbb',
+    },
+  ])('generates expected relative path', ({ fromDirectory, to, expected }) => {
+    const actual = makeRelativePath({ fromDirectory, to });
+    expect(actual).toBe(expected);
+  });
+});

--- a/test/unit/refToPath.test.ts
+++ b/test/unit/refToPath.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { refToPath } from '../../src/utils';
 
-describe('refToPath', async () => {
-  it('generate expected ref paths', async () => {
+describe('refToPath', () => {
+  it('generate expected ref paths', () => {
     const actual = refToPath('#/components/schema/Foo');
     const expected = {
       schemaName: 'Foo',

--- a/test/unit/replaceInlinedRefsWithStringPlaceholder.test.ts
+++ b/test/unit/replaceInlinedRefsWithStringPlaceholder.test.ts
@@ -4,8 +4,8 @@ import {
   REF_SYMBOL,
 } from '../../src/utils';
 
-describe('replaceInlinedRefsWithStringPlaceholder', async () => {
-  it('replaces objects marked with REF_SYMBOL with expected string placeholder', async () => {
+describe('replaceInlinedRefsWithStringPlaceholder', () => {
+  it('replaces objects marked with REF_SYMBOL with expected string placeholder', () => {
     const actual = replaceInlinedRefsWithStringPlaceholder({
       schemas: {
         object: {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

Broken sibling schemas relative imports generated.

## What is the new behaviour?

Generate the expected relative imports. Relative import path generation function isolated and tested.

## Does this PR introduce a breaking change?

What changes might users need to make in their application due to this PR?

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
