### PR TITLE
fix: `isRef` meta data prop for inline refHandling

### DIFF
--- a/.changeset/purple-ducks-rule.md
+++ b/.changeset/purple-ducks-rule.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-json-schema': patch
+---
+
+Fix `isRef` meta data prop for inline refHandling

--- a/src/openapiToTsJsonSchema.ts
+++ b/src/openapiToTsJsonSchema.ts
@@ -142,7 +142,7 @@ export async function openapiToTsJsonSchema({
         outputPath,
         schemaPatcher,
         refHandling,
-        isRef: false,
+        isRef: inlinedRefs.has(id),
       });
     }
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

`isRef` meta data prop always false when on inline refHandling

## What is the new behaviour?

`isRef` true for generated schemas which are used as `ref`.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
