### PR TITLE
feat: make utils available to plugin functions

### DIFF
--- a/.changeset/pretty-carpets-battle.md
+++ b/.changeset/pretty-carpets-battle.md
@@ -2,4 +2,4 @@
 'openapi-ts-json-schema': minor
 ---
 
-Introduce plugins option
+Introduce `plugins` option

--- a/.changeset/purple-ducks-rule.md
+++ b/.changeset/purple-ducks-rule.md
@@ -2,4 +2,4 @@
 'openapi-ts-json-schema': patch
 ---
 
-Fix `isRef` meta data prop for inline refHandling
+Fix `isRef` meta data prop for inline `refHandling` option

--- a/.changeset/sixty-fireants-poke.md
+++ b/.changeset/sixty-fireants-poke.md
@@ -2,4 +2,4 @@
 'openapi-ts-json-schema': minor
 ---
 
-Add "keep" refHandling option, to preserve $ref objects
+Add "keep" `refHandling` option, to preserve $ref objects

--- a/README.md
+++ b/README.md
@@ -102,16 +102,17 @@ Beside generating the expected schema files under `outputPath`, `openapiToTsJson
 
 ## Plugins
 
-`metaData` output can be used to dynamically generate extra custom output based on the generated schemas.
+`openapi-ts-json-schema` plugins are intended as a way to generate extra artifacts based on the same internal metadata created to generate the JSON schema output.
 
-`openapi-ts-json-schema` currently ships with one plugin specifically designed to better integrate with [Fastify](https://fastify.dev/).
+`openapi-ts-json-schema` currently ships with one plugin specifically designed to better integrate with [Fastify](https://fastify.dev/), and you can write your owns.
 
-Read more about plugins in the [dedicated readme](./docs/plugins.md).
+Read [plugins documentation 📖](./docs/plugins.md).
 
 ## Todo
 
 - Consider merging "operation" and "path" parameters definition
 - Consider removing required `definitionPathsToGenerateFrom` option in favour of exporting the whole OpenAPI definitions based on the structure defined in specs
+- Consider adding a way to customize the values of the generated JSON schema ids. This could be beneficial even in case of multiple schemas being merged with plugins
 
 [ci-badge]: https://github.com/toomuchdesign/openapi-ts-json-schema/actions/workflows/ci.yml/badge.svg
 [ci]: https://github.com/toomuchdesign/openapi-ts-json-schema/actions/workflows/ci.yml

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -88,8 +88,8 @@ import type { Plugin } from 'openapi-ts-json-schema';
 // An `openapi-ts-json-schema` consists of a factory function returning an async function
 const myPlugin: Plugin<{ optionOne: string; optionTwo: string }> =
   ({ optionOne, optionTwo }) =>
-  async ({ outputPath, metaData }) => {
-    // You custom implementation
+  async ({ outputPath, metaData, utils }) => {
+    // Your custom implementation...
   };
 
 export myPlugin;

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,5 +1,10 @@
 # Plugins
 
+`openapi-ts-json-schema` plugins are intended as a way to generate extra artifacts based on the same internal metadata created to generate the JSON schema output.
+
+- [Fastify type provider plugin](#fastify-type-provider-plugin)
+- [Write your own plugin](#write-your-own-plugin)
+
 ## Fastify type provider plugin
 
 This plugin generate the necessary connective tissue to optimally integrate `openapi-ts-json-schema` output with Fastify's [`json-schema-to-ts` type provider](https://github.com/fastify/fastify-type-provider-json-schema-to-ts) preserving JSON schemas `$ref`s.
@@ -17,7 +22,7 @@ import {
   fastifyTypeProviderPlugin,
 } from 'openapi-ts-json-schema';
 
-const { outputPath, metaData } = await openapiToTsJsonSchema({
+await openapiToTsJsonSchema({
   openApiSchema: path.resolve(fixtures, 'path/to/open-api-spec.yaml'),
   outputPath: 'path/to/generated/schemas',
   definitionPathsToGenerateFrom: ['components.schemas', 'paths'],
@@ -71,4 +76,34 @@ fastify.get(
     const { givenName, familyName } = req.body.user;
   },
 );
+```
+
+## Write your own plugin
+
+`openapi-ts-json-schema` exposes a TS type to support plugins implementation:
+
+```ts
+import type { Plugin } from 'openapi-ts-json-schema';
+
+// An `openapi-ts-json-schema` consists of a factory function returning an async function
+const myPlugin: Plugin<{ optionOne: string; optionTwo: string }> =
+  ({ optionOne, optionTwo }) =>
+  async ({ outputPath, metaData }) => {
+    // You custom implementation
+  };
+
+export myPlugin;
+```
+
+...import and instantiate your plugin:
+
+```ts
+import { openapiToTsJsonSchema } from 'openapi-ts-json-schema';
+import { myPlugin } from '../myPlugin';
+
+await openapiToTsJsonSchema({
+  openApiSchema: 'path/to/open-api-specs.yaml',
+  definitionPathsToGenerateFrom: ['components.schemas'],
+  plugins: [myPlugin({ optionOne: 'foo', optionTwo: 'bar' })],
+});
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { openapiToTsJsonSchema } from './openapiToTsJsonSchema';
+export { Plugin } from './types';
 export { default as fastifyTypeProviderPlugin } from './plugins/fastifyTypeProviderPlugin';

--- a/src/openapiToTsJsonSchema.ts
+++ b/src/openapiToTsJsonSchema.ts
@@ -157,7 +157,7 @@ export async function openapiToTsJsonSchema({
     metaData: { schemas: schemaMetaDataMap },
   };
 
-  // Process plugins
+  // Execute plugins
   for (const plugin of plugins) {
     await plugin(returnPayload);
   }

--- a/src/openapiToTsJsonSchema.ts
+++ b/src/openapiToTsJsonSchema.ts
@@ -12,6 +12,9 @@ import {
   convertOpenApiParameters,
   addSchemaToMetaData,
   pathToRef,
+  formatTypeScript,
+  saveFile,
+  makeRelativePath,
 } from './utils';
 import type {
   SchemaPatcher,
@@ -159,7 +162,10 @@ export async function openapiToTsJsonSchema({
 
   // Execute plugins
   for (const plugin of plugins) {
-    await plugin(returnPayload);
+    await plugin({
+      ...returnPayload,
+      utils: { makeRelativePath, formatTypeScript, saveFile },
+    });
   }
 
   if (!silent) {

--- a/src/plugins/fastifyTypeProviderPlugin.ts
+++ b/src/plugins/fastifyTypeProviderPlugin.ts
@@ -1,11 +1,10 @@
-import { makeRelativePath, formatTypeScript, saveFile } from '../utils';
 import type { Plugin, SchemaMetaData } from '../types';
 
 const FILE_NAME = 'fastifyTypeProvider.ts';
 
 const fastifyTypeProviderPlugin: Plugin =
   () =>
-  async ({ outputPath, metaData }) => {
+  async ({ outputPath, metaData, utils }) => {
     const refSchemaMetaData: SchemaMetaData[] = [];
     metaData.schemas.forEach((schema) => {
       if (schema.isRef) {
@@ -16,7 +15,7 @@ const fastifyTypeProviderPlugin: Plugin =
     const schemas = refSchemaMetaData.map(
       ({ schemaAbsoluteImportPath, schemaUniqueName, schemaId }) => {
         return {
-          importPath: makeRelativePath({
+          importPath: utils.makeRelativePath({
             fromDirectory: outputPath,
             to: schemaAbsoluteImportPath,
           }),
@@ -53,8 +52,8 @@ const fastifyTypeProviderPlugin: Plugin =
       ${schemas.map((schema) => `${schema.schemaUniqueName}WithId`).join(',')}
   ];`;
 
-    const formattedOutput = await formatTypeScript(output);
-    await saveFile({
+    const formattedOutput = await utils.formatTypeScript(output);
+    await utils.saveFile({
       path: [outputPath, FILE_NAME],
       data: formattedOutput,
     });

--- a/src/plugins/fastifyTypeProviderPlugin.ts
+++ b/src/plugins/fastifyTypeProviderPlugin.ts
@@ -39,7 +39,7 @@ const fastifyTypeProviderPlugin: Plugin =
 
     // Generate a TS tuple type containing the types of all $ref schema found
     output += `\n\n
-    export type References = [
+    export type RefSchemas = [
       ${schemas
         .map((schema) => `typeof ${schema.schemaUniqueName}WithId`)
         .join(',')}
@@ -48,7 +48,7 @@ const fastifyTypeProviderPlugin: Plugin =
     // Generate an array af all $ref schema
     // @TODO make selected schemas configurable
     output += `\n\n
-    export const referenceSchemas = [
+    export const refSchemas = [
       ${schemas.map((schema) => `${schema.schemaUniqueName}WithId`).join(',')}
   ];`;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
 export type JSONSchema = JSONSchema4 | JSONSchema6 | JSONSchema7;
 export type OpenApiSchema = Record<string, any>;
 export type SchemaPatcher = (params: { schema: JSONSchema }) => void;
+import type { makeRelativePath, formatTypeScript, saveFile } from './utils';
 
 /**
  * @prop `schemaFileName` - Valid filename for given schema (without extension). Eg: `"MySchema"`
@@ -34,6 +35,14 @@ export type ReturnPayload = {
   metaData: { schemas: SchemaMetaDataMap };
 };
 
+type PluginInput = ReturnPayload & {
+  utils: {
+    makeRelativePath: typeof makeRelativePath;
+    formatTypeScript: typeof formatTypeScript;
+    saveFile: typeof saveFile;
+  };
+};
+
 export type Plugin<Options = void> = (
   options: Options,
-) => (args: ReturnPayload) => Promise<void>;
+) => (input: PluginInput) => Promise<void>;

--- a/test/plugins/fastifyTypeProviderPlugin.test.ts
+++ b/test/plugins/fastifyTypeProviderPlugin.test.ts
@@ -43,13 +43,13 @@ describe('fastifyTypeProviderPlugin plugin', () => {
         $id: "#/components/months/February",
       } as const;
 
-      export type References = [
+      export type RefSchemas = [
         typeof componentsSchemasAnswerWithId,
         typeof componentsMonthsJanuaryWithId,
         typeof componentsMonthsFebruaryWithId,
       ];
 
-      export const referenceSchemas = [
+      export const refSchemas = [
         componentsSchemasAnswerWithId,
         componentsMonthsJanuaryWithId,
         componentsMonthsFebruaryWithId,
@@ -71,7 +71,7 @@ describe('fastifyTypeProviderPlugin plugin', () => {
       path.resolve(outputPath, 'fastifyTypeProvider')
     );
 
-    expect(actualParsed.referenceSchemas).toEqual([
+    expect(actualParsed.refSchemas).toEqual([
       { ...answerSchema.default, $id: '#/components/schemas/Answer' },
       { ...januarySchema.default, $id: '#/components/months/January' },
       { ...februarySchema.default, $id: '#/components/months/February' },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature/Refactor

## What is the current behaviour?

Custom plugins must re-implement formatting, save and relative path functions

## What is the new behaviour?

Inject a 3rd `utils` prop in plugin object prop

Fastify plugin generating refSchemas and RefSchemas exports

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [ ] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
