### PR TITLE
feat: add `sharedSchemasFilter` option to fastify plugin

### DIFF
--- a/test/plugins/fastifyTypeProviderPlugin.test.ts
+++ b/test/plugins/fastifyTypeProviderPlugin.test.ts
@@ -18,7 +18,7 @@ describe('fastifyTypeProviderPlugin plugin', () => {
     });
 
     const actualAsText = await fs.readFile(
-      path.resolve(outputPath, 'fastifyTypeProvider.ts'),
+      path.resolve(outputPath, 'fastify-type-provider.ts'),
       {
         encoding: 'utf8',
       },
@@ -53,11 +53,13 @@ describe('fastifyTypeProviderPlugin plugin', () => {
         componentsSchemasAnswerWithId,
         componentsMonthsJanuaryWithId,
         componentsMonthsFebruaryWithId,
-      ]`);
+      ]
+
+      export const sharedSchemas = []`);
 
     expect(actualAsText).toBe(expectedAsText);
 
-    // Ref schemas for fastify.addSchema
+    // refSchemas containing only $ref schemas
     const answerSchema = await import(
       path.resolve(outputPath, 'components/schemas/Answer')
     );
@@ -67,14 +69,64 @@ describe('fastifyTypeProviderPlugin plugin', () => {
     const februarySchema = await import(
       path.resolve(outputPath, 'components/months/February')
     );
-    const actualParsed = await import(
-      path.resolve(outputPath, 'fastifyTypeProvider')
+    const actual = await import(
+      path.resolve(outputPath, 'fastify-type-provider')
     );
 
-    expect(actualParsed.refSchemas).toEqual([
+    expect(actual.refSchemas).toEqual([
       { ...answerSchema.default, $id: '#/components/schemas/Answer' },
       { ...januarySchema.default, $id: '#/components/months/January' },
       { ...februarySchema.default, $id: '#/components/months/February' },
     ]);
+
+    expect(actual.sharedSchemas).toEqual([]);
+  });
+
+  describe('"sharedSchemasFilter" option', () => {
+    it('generates expected file', async () => {
+      const { outputPath } = await openapiToTsJsonSchema({
+        openApiSchema: path.resolve(fixtures, 'complex/specs.yaml'),
+        outputPath: makeTestOutputPath('plugin-fastify'),
+        definitionPathsToGenerateFrom: ['components.months', 'paths'],
+        refHandling: 'keep',
+        plugins: [
+          fastifyTypeProviderPlugin({
+            sharedSchemasFilter: ({ schemaId }) =>
+              schemaId.startsWith('#/components/months'),
+          }),
+        ],
+        silent: true,
+      });
+
+      const actual = await import(
+        path.resolve(outputPath, 'fastify-type-provider')
+      );
+
+      // refSchemas containing only $ref schemas
+      const answerSchema = await import(
+        path.resolve(outputPath, 'components/schemas/Answer')
+      );
+      const januarySchema = await import(
+        path.resolve(outputPath, 'components/months/January')
+      );
+      const februarySchema = await import(
+        path.resolve(outputPath, 'components/months/February')
+      );
+
+      expect(actual.refSchemas).toEqual([
+        { ...answerSchema.default, $id: '#/components/schemas/Answer' },
+        { ...januarySchema.default, $id: '#/components/months/January' },
+        { ...februarySchema.default, $id: '#/components/months/February' },
+      ]);
+
+      // refSchemas containing only non-$ref schemas
+      const marchSchema = await import(
+        path.resolve(outputPath, 'components/months/March')
+      );
+
+      expect(actual.sharedSchemas).toEqual([
+        { ...marchSchema.default, $id: '#/components/months/March' },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behaviour?

Cannot re-export openAPI shared components

## What is the new behaviour?

Add support for `fastifyTypeProviderPlugin` `sharedSchemasFilter` option to generate a list of user-selected schemas ready to be registered with `fastify.addSchema`.

The list is exposed as `sharedSchemas`.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [ ] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
