### PR TITLE
fix: external local `$ref`s resolution

### DIFF
--- a/.changeset/smooth-garlics-deny.md
+++ b/.changeset/smooth-garlics-deny.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-json-schema': patch
+---
+
+Fix external local `$ref`s resolution

--- a/src/openapiToTsJsonSchema.ts
+++ b/src/openapiToTsJsonSchema.ts
@@ -1,8 +1,6 @@
-import fs from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'node:path';
 import $RefParser from '@apidevtools/json-schema-ref-parser';
-import YAML from 'yaml';
 import get from 'lodash.get';
 import {
   clearFolder,
@@ -68,10 +66,7 @@ export async function openapiToTsJsonSchema({
 
   await clearFolder(outputPath);
 
-  const openApiSchema = await fs.readFile(openApiSchemaPath, 'utf-8');
-  const jsonOpenApiSchema: Record<string, any> = YAML.parse(openApiSchema);
-  // Resolve/inline remote and URL $ref's (keeping local ones "#/...")
-  const bundledOpenApiSchema = await $RefParser.bundle(jsonOpenApiSchema);
+  const bundledOpenApiSchema = await $RefParser.bundle(openApiSchemaPath);
   const initialJsonSchema = convertOpenApiToJsonSchema(bundledOpenApiSchema);
 
   const inlinedRefs: Map<string, JSONSchema> = new Map();

--- a/test/externalRefs.test.ts
+++ b/test/externalRefs.test.ts
@@ -17,7 +17,7 @@ describe('External $ref', () => {
     );
 
     expect(externalDefinitionSchema.default).toEqual({
-      description: 'External Foo description',
+      description: 'External Foo 1 description',
       type: ['string', 'null'],
       enum: ['yes', 'no', null],
     });
@@ -33,7 +33,7 @@ describe('External $ref', () => {
       type: 'object',
       properties: {
         remoteDefinition: {
-          description: 'External Foo description',
+          description: 'External Foo 1 description',
           type: ['string', 'null'],
           enum: ['yes', 'no', null],
         },

--- a/test/fixtures/external-ref/external-definition-1.yaml
+++ b/test/fixtures/external-ref/external-definition-1.yaml
@@ -5,15 +5,15 @@ info:
   version: 1.0.0
 components:
   schemas:
-    Foo:
-      description: External Foo description
+    Foo1:
+      description: External Foo 1 description
       type: string
       nullable: true
       enum:
         - yes
         - no
-    Bar:
-      description: External Bar description
+    Bar1:
+      description: External Bar 1 description
       type: string
       nullable: true
       enum:

--- a/test/fixtures/external-ref/specs.yaml
+++ b/test/fixtures/external-ref/specs.yaml
@@ -11,4 +11,4 @@ components:
         remoteDefinition:
           $ref: '#/components/schemas/ExternalDefinition'
     ExternalDefinition:
-      $ref: 'test/fixtures/external-ref/external-definition.yaml#/components/schemas/Foo'
+      $ref: './external-definition-1.yaml#/components/schemas/Foo1'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

`$RefParser.bundle()` not being able to resolve external local `$ref`s since it misses the baseUrl information.

## What is the new behaviour?

Provide `$RefParser.bundle()` with the absolute schema path instead of the schema entity and delegate bundling and YAML -> json conversion to it. 

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
