### PR TITLE
fix: do not duplicate alias definitions

### DIFF
--- a/.changeset/smooth-seahorses-add.md
+++ b/.changeset/smooth-seahorses-add.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-json-schema': patch
+---
+
+Don't duplicate alias definitions but re-export original schema

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Beside generating the expected schema files under `outputPath`, `openapiToTsJson
         // Absolute import path (without extension). Eg: `"/output/path/components/schemas/MySchema"`
         schemaUniqueName: string;
         // Unique JavaScript identifier used as import name. Eg: `"componentsSchemasMySchema"`
-        schema: JSONSchema;
-        // The actual JSON schema
+        schema: JSONSchema | string;
+        // JSON schema value with $refs replaced by a placeholder
         isRef: boolean;
         // True if schemas is used as a `$ref`
       }

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -16,7 +16,7 @@ At the time of writing the implementation is build around `@apidevtools/json-sch
 ```ts
 {
   bar: {
-    [Symbol('ref')]: '#/foo/Bar',
+    [Symbol('ref')]: '#/components/schemas/Bar',
     // ...Inlined schema props
   }
 }
@@ -26,8 +26,14 @@ At the time of writing the implementation is build around `@apidevtools/json-sch
 
 ```ts
 {
-  bar: '_OTJS-START_#/foo/Bar_OTJS-END_';
+  bar: '_OTJS-START_#/components/schemas/Bar_OTJS-END_';
 }
+```
+
+Note: alias definitions (eg. `Foo: "#components/schemas/Bar"`) will result in a plain **string placeholder**.
+
+```ts
+'_OTJS-START_#/components/schemas/Bar_OTJS-END_';
 ```
 
 4. Inlined and dereferenced schemas get stringified and parsed to retrieve **string placeholders** and the contained original `$ref` value
@@ -37,9 +43,9 @@ At the time of writing the implementation is build around `@apidevtools/json-sch
 ```ts
 import Bar from '../foo/Bar';
 
-{
+export default {
   bar: Bar;
-}
+} as const
 ```
 
 This process could be definitely shorter if `@apidevtools/json-schema-ref-parser`'s `dereference` method allowed to access the parent object holding the `$ref` value to be replaced. In that case step 2 could be skipped and the ref object could be immediately replaced with the relevant **string placeholder**.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
 export type JSONSchema = JSONSchema4 | JSONSchema6 | JSONSchema7;
+export type JSONSchemaWithPlaceholders = JSONSchema | string;
 export type OpenApiSchema = Record<string, any>;
 export type SchemaPatcher = (params: { schema: JSONSchema }) => void;
 import type { makeRelativePath, formatTypeScript, saveFile } from './utils';
@@ -11,7 +12,7 @@ import type { makeRelativePath, formatTypeScript, saveFile } from './utils';
  * @prop `schemaAbsoluteImportPath` - Absolute import path (without extension). Eg: `"/output/path/components/schemas/MySchema"`
  * @prop `schemaUniqueName` - Unique JavaScript identifier used as import name. Eg: `"componentsSchemasMySchema"`
  * @prop `schemaId` - JSON schema Compound Schema Document `$id`. Eg `"/components/schemas/MySchema"`
- * @prop `schema` - The actual JSON schema
+ * @prop `schema` - JSON schema value with $refs replaced by a placeholder
  * @prop `isRef` - True if schemas is used as a `$ref`
  */
 export type SchemaMetaData = {
@@ -21,7 +22,7 @@ export type SchemaMetaData = {
   schemaAbsoluteImportPath: string;
   schemaUniqueName: string;
   schemaId: string;
-  schema: JSONSchema;
+  schema: JSONSchemaWithPlaceholders;
   isRef: boolean;
 };
 

--- a/src/utils/addSchemaToMetaData.ts
+++ b/src/utils/addSchemaToMetaData.ts
@@ -39,11 +39,15 @@ export function addSchemaToMetaData({
   if (schemaMetaDataMap.has(ref) === false) {
     const { schemaRelativeDirName, schemaName, schemaRelativePath } =
       refToPath(ref);
-    const originalSchema =
+    // Shall we generate the actual final schema here instead of makeJsonSchemaFiles?
+    const schemaWithPlaceholders =
       refHandling === 'import' || refHandling === 'keep'
         ? replaceInlinedRefsWithStringPlaceholder(schema)
         : schema;
-    const patchedSchema = patchJsonSchema(originalSchema, schemaPatcher);
+    const isAlias = typeof schemaWithPlaceholders === 'string';
+    const patchedSchema = isAlias
+      ? schemaWithPlaceholders
+      : patchJsonSchema(schemaWithPlaceholders, schemaPatcher);
     const schemaAbsoluteDirName = path.join(outputPath, schemaRelativeDirName);
     const schemaFileName = filenamify(schemaName, { replacement: '|' });
     const schemaAbsoluteImportPath = path.join(

--- a/src/utils/jsonSchemaToTsConst/index.ts
+++ b/src/utils/jsonSchemaToTsConst/index.ts
@@ -20,7 +20,16 @@ export async function jsonSchemaToTsConst({
    * to generate inline comments for "inline" refHandling
    */
   const stringifiedSchema = stringify(schema, null, 2);
-  let tsSchema = `export default ` + stringifiedSchema + ' as const;';
+
+  /**
+   * Schemas being just a placeholder are nothing but an alias
+   * of the definition found in the placeholder
+   */
+  const isAlias = typeof schema === 'string';
+  let tsSchema =
+    isAlias && refHandling === 'import'
+      ? `export default ` + stringifiedSchema + ';'
+      : `export default ` + stringifiedSchema + ' as const;';
 
   if (refHandling === 'import') {
     tsSchema = replacePlaceholdersWithImportedSchemas({

--- a/src/utils/replaceInlinedRefsWithStringPlaceholder.ts
+++ b/src/utils/replaceInlinedRefsWithStringPlaceholder.ts
@@ -1,6 +1,6 @@
 import mapObject from 'map-obj';
 import { refToPlaceholder, REF_SYMBOL } from '.';
-import type { JSONSchema } from '../types';
+import type { JSONSchema, JSONSchemaWithPlaceholders } from '../types';
 
 function isObject(value: unknown): value is Record<string | symbol, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -42,7 +42,11 @@ function replaceInlinedSchemaWithPlaceholder<Node extends unknown>(
  */
 export function replaceInlinedRefsWithStringPlaceholder(
   schema: JSONSchema,
-): JSONSchema {
+): JSONSchemaWithPlaceholders {
+  if (getRef(schema)) {
+    return replaceInlinedSchemaWithPlaceholder(schema);
+  }
+
   return mapObject(
     schema,
     (key, value) => {

--- a/test/externalRefs.test.ts
+++ b/test/externalRefs.test.ts
@@ -76,7 +76,7 @@ describe('External $refs', () => {
   // @NOTE this feature has not been implemented
   describe('refHandling option === "import"', () => {
     describe('openAPI definitions imported multiple times', () => {
-      it.fails('dedupe imports and resolve against same schema', async () => {
+      it('dedupe imports and resolve against same schema', async () => {
         const { outputPath } = await openapiToTsJsonSchema({
           openApiSchema: path.resolve(fixtures, 'external-ref/specs.yaml'),
           outputPath: makeTestOutputPath('external-refs'),

--- a/test/fixtures/alias-definitions/specs.yaml
+++ b/test/fixtures/alias-definitions/specs.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.3
+info:
+  title: title
+  description: description
+  version: 1.0.0
+components:
+  schemas:
+    Answer:
+      type: string
+      nullable: true
+      enum:
+        - yes
+        - no
+    AnswerAliasDefinition:
+      $ref: '#/components/schemas/Answer'
+
+servers:
+  - url: url

--- a/test/refHandling-import.test.ts
+++ b/test/refHandling-import.test.ts
@@ -158,4 +158,27 @@ describe('refHandling option === "import"', () => {
 
     expect(actualFebruarySchemaFile).toMatch(expectedFebruarySchemaFile);
   });
+
+  describe('Alias definitions', () => {
+    it('re-exports original definition', async () => {
+      const { outputPath } = await openapiToTsJsonSchema({
+        openApiSchema: path.resolve(fixtures, 'alias-definitions/specs.yaml'),
+        outputPath: makeTestOutputPath('refHandling-import-alias-definitions'),
+        definitionPathsToGenerateFrom: ['components.schemas'],
+        silent: true,
+        refHandling: 'import',
+      });
+
+      const answerSchema = await import(
+        path.resolve(outputPath, 'components/schemas/Answer')
+      );
+
+      const answerAliasDefinition = await import(
+        path.resolve(outputPath, 'components/schemas/AnswerAliasDefinition')
+      );
+
+      expect(answerSchema.default).toEqual(answerAliasDefinition.default);
+      expect(answerSchema.default).toBe(answerAliasDefinition.default);
+    });
+  });
 });

--- a/test/refHandling-keep.test.ts
+++ b/test/refHandling-keep.test.ts
@@ -1,7 +1,9 @@
 import path from 'path';
+import fs from 'fs/promises';
 import { describe, it, expect } from 'vitest';
 import { fixtures, makeTestOutputPath } from './test-utils';
 import { openapiToTsJsonSchema } from '../src';
+import { formatTypeScript } from '../src/utils';
 
 describe('refHandling option === "keep"', () => {
   it('Generates expected schemas preserving $ref pointer', async () => {
@@ -35,6 +37,38 @@ describe('refHandling option === "keep"', () => {
         },
       },
     });
+
+    // Expectations against actual root schema file
+    const actualPath1File = await fs.readFile(
+      path.resolve(outputPath, 'paths/v1|path-1.ts'),
+      {
+        encoding: 'utf8',
+      },
+    );
+
+    // Ensure "as const" is present
+    const expectedPath1File = await formatTypeScript(`
+      export default {
+        get: {
+          responses: {
+            "200": {
+              description: "A description",
+              content: {
+                "application/json": {
+                  schema: {
+                    oneOf: [
+                      { $ref: "#/components/months/January" },
+                      { $ref: "#/components/months/February" }
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as const;`);
+
+    expect(actualPath1File).toEqual(expectedPath1File);
   });
 
   it('Generates expected $ref schemas preserving $ref pointer', async () => {
@@ -65,6 +99,40 @@ describe('refHandling option === "keep"', () => {
     expect(answerSchema.default).toEqual({
       type: ['string', 'null'],
       enum: ['yes', 'no', null],
+    });
+  });
+
+  describe('Alias definitions', () => {
+    it('generate expected $ref object', async () => {
+      const { outputPath } = await openapiToTsJsonSchema({
+        openApiSchema: path.resolve(fixtures, 'alias-definitions/specs.yaml'),
+        outputPath: makeTestOutputPath('refHandling-keep-alias-definitions'),
+        definitionPathsToGenerateFrom: ['components.schemas'],
+        silent: true,
+        refHandling: 'keep',
+      });
+
+      const answerAliasDefinition = await import(
+        path.resolve(outputPath, 'components/schemas/AnswerAliasDefinition')
+      );
+
+      expect(answerAliasDefinition.default).toEqual({
+        $ref: '#/components/schemas/Answer',
+      });
+
+      // Ensure "as const" is present
+      const answerAliasDefinitionFile = await fs.readFile(
+        path.resolve(outputPath, 'components/schemas/AnswerAliasDefinition.ts'),
+        {
+          encoding: 'utf8',
+        },
+      );
+
+      expect(answerAliasDefinitionFile).toEqual(
+        await formatTypeScript(`
+          export default { $ref: '#/components/schemas/Answer' } as const;
+        `),
+      );
     });
   });
 });

--- a/test/unit/replaceInlinedRefsWithStringPlaceholder.test.ts
+++ b/test/unit/replaceInlinedRefsWithStringPlaceholder.test.ts
@@ -5,28 +5,43 @@ import {
 } from '../../src/utils';
 
 describe('replaceInlinedRefsWithStringPlaceholder', () => {
-  it('replaces objects marked with REF_SYMBOL with expected string placeholder', () => {
-    const actual = replaceInlinedRefsWithStringPlaceholder({
-      schemas: {
-        object: {
-          foo: 'bar',
-          [REF_SYMBOL]: '#/ref/in/object',
+  describe('nested object market with REF_SYMBOL', () => {
+    it('replaces objects with expected string placeholder', () => {
+      const actual = replaceInlinedRefsWithStringPlaceholder({
+        schemas: {
+          object: {
+            foo: 'bar',
+            [REF_SYMBOL]: '#/ref/in/object',
+          },
+          array: [
+            'foo',
+            { hello: 'world', [REF_SYMBOL]: '#/ref/in/array' },
+            'bar',
+          ],
         },
-        array: [
-          'foo',
-          { hello: 'world', [REF_SYMBOL]: '#/ref/in/array' },
-          'bar',
-        ],
-      },
+      });
+
+      const expected = {
+        schemas: {
+          object: '_OTJS-START_#/ref/in/object_OTJS-END_',
+          array: ['foo', '_OTJS-START_#/ref/in/array_OTJS-END_', 'bar'],
+        },
+      };
+
+      expect(actual).toEqual(expected);
     });
+  });
 
-    const expected = {
-      schemas: {
-        object: '_OTJS-START_#/ref/in/object_OTJS-END_',
-        array: ['foo', '_OTJS-START_#/ref/in/array_OTJS-END_', 'bar'],
-      },
-    };
+  describe('root object market with REF_SYMBOL (alias definitions)', () => {
+    it('replaces object with expected string placeholder', () => {
+      // @ts-expect-error REF_SYMBOL is not a valid JSON schema prop
+      const actual = replaceInlinedRefsWithStringPlaceholder({
+        type: 'object',
+        [REF_SYMBOL]: '#/ref/in/root/object',
+      });
+      const expected = '_OTJS-START_#/ref/in/root/object_OTJS-END_';
 
-    expect(actual).toEqual(expected);
+      expect(actual).toEqual(expected);
+    });
   });
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

Alias definition schemas (`Foo: "#/components/schemas/Bar"`) being duplicated.

## What is the new behaviour?

Alias definition schemas get generated as modules re-exporting the $ref schema.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
