### PR TITLE
feat: throw error with circular schemas and inline refHandling option

### DIFF
--- a/.changeset/rude-oranges-worry.md
+++ b/.changeset/rude-oranges-worry.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-json-schema': minor
+---
+
+Throw descriptive error with circular schemas and inline refHandling option


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behaviour?

#158 

## What is the new behaviour?

Throw descriptive error with circular schemas and inline refHandling option

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
