### PR TITLE
feat: add inline comment on circular ref resolution truncation

### DIFF
--- a/src/utils/makeTsJsonSchema/getCircularReplacer.ts
+++ b/src/utils/makeTsJsonSchema/getCircularReplacer.ts
@@ -1,3 +1,5 @@
+import { REF_SYMBOL } from '../';
+
 /**
  * JSON.stringify replacer
  * Replace circular references with {}
@@ -21,7 +23,17 @@ export function getCircularReplacer(): (
 
     // @NOTE Should we make recursion depth configurable?
     if (ancestors.includes(value)) {
-      return {};
+      // @ts-expect-error REF_SYMBOL doesn't exist on value
+      const ref = value[REF_SYMBOL];
+      return {
+        // Drop an inline comment about recursion interruption
+        [Symbol.for('before')]: [
+          {
+            type: 'LineComment',
+            value: ` Circular recursion interrupted (${ref})`,
+          },
+        ],
+      };
     }
 
     ancestors.push(value);

--- a/test/refHandling-inline.test.ts
+++ b/test/refHandling-inline.test.ts
@@ -21,7 +21,7 @@ describe('refHandling option === "inline"', () => {
       },
     );
 
-    const expectedInlinedRef = await `
+    const expectedInlinedRef = `
   properties: {
     isJanuary: {
       // $ref: "#/components/schemas/Answer"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature 

## What is the new behaviour?

add inline comment on circular ref resolution truncation

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
