### PR TITLE
fix: append type object prop to generated parameter schemas

### DIFF
--- a/.changeset/purple-students-breathe.md
+++ b/.changeset/purple-students-breathe.md
@@ -1,0 +1,5 @@
+---
+"openapi-ts-json-schema": patch
+---
+
+Append `type: "object"` prop to generated parameter schemas

--- a/src/utils/convertOpenApiParameters.ts
+++ b/src/utils/convertOpenApiParameters.ts
@@ -1,5 +1,25 @@
-import { convertParametersToJSONSchema } from 'openapi-jsonschema-parameters';
+import {
+  convertParametersToJSONSchema as _convertParametersToJSONSchema,
+  OpenAPIParametersAsJSONSchema,
+} from 'openapi-jsonschema-parameters';
 import type { JSONSchema } from '../types';
+
+type OpenAPIParameters = Parameters<typeof _convertParametersToJSONSchema>[0];
+function convertParametersToJSONSchema(
+  openApiParameters: OpenAPIParameters,
+): OpenAPIParametersAsJSONSchema {
+  const parameters = _convertParametersToJSONSchema(openApiParameters);
+
+  // Append "type" prop which "openapi-jsonschema-parameters" seems to omit
+  let paramName: keyof OpenAPIParametersAsJSONSchema;
+  for (paramName in parameters) {
+    const schema = parameters[paramName];
+    if (schema && !schema.type) {
+      schema.type = 'object';
+    }
+  }
+  return parameters;
+}
 
 /**
  * Parameters field can only be found in:
@@ -8,7 +28,7 @@ import type { JSONSchema } from '../types';
  *
  * https://swagger.io/docs/specification/describing-parameters/
  */
-export function convertOpenApiParameters(schema: JSONSchema) {
+export function convertOpenApiParameters(schema: JSONSchema): JSONSchema {
   if ('paths' in schema) {
     for (const path in schema.paths) {
       const pathSchema = schema.paths[path];

--- a/test/parameters.test.ts
+++ b/test/parameters.test.ts
@@ -19,6 +19,7 @@ describe('OpenAPI parameters', () => {
     expect(pathSchema.default).toEqual({
       parameters: {
         headers: {
+          type: 'object',
           required: ['path-headers-param-1'],
           properties: {
             'path-headers-param-1': {
@@ -30,6 +31,7 @@ describe('OpenAPI parameters', () => {
       get: {
         parameters: {
           headers: {
+            type: 'object',
             properties: {
               'headers-param-1': {
                 type: 'string',
@@ -43,6 +45,7 @@ describe('OpenAPI parameters', () => {
           },
           body: { type: 'string', enum: ['foo', 'bar'] },
           path: {
+            type: 'object',
             properties: {
               'path-param-1': {
                 type: 'string',
@@ -51,6 +54,7 @@ describe('OpenAPI parameters', () => {
             required: ['path-param-1'],
           },
           query: {
+            type: 'object',
             properties: {
               'query-param-1': {
                 type: 'string',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

Generated parameter schemas missing JSON schema `type` prop.

## What is the new behaviour?

Append `type: "object"` prop to generated parameter schemas

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
