### PR TITLE
fix: inlined schemas out of components prop not being converted to JSON schema

### DIFF
--- a/.changeset/sixty-ears-cheat.md
+++ b/.changeset/sixty-ears-cheat.md
@@ -1,0 +1,5 @@
+---
+"openapi-ts-json-schema": patch
+---
+
+Convert to JSON schema definitions inlined in other places then components prop

--- a/src/utils/convertOpenApiPathsParameters.ts
+++ b/src/utils/convertOpenApiPathsParameters.ts
@@ -1,15 +1,15 @@
 import {
-  convertParametersToJSONSchema as _convertParametersToJSONSchema,
+  convertParametersToJSONSchema,
   OpenAPIParametersAsJSONSchema,
 } from 'openapi-jsonschema-parameters';
 import type { JSONSchema } from '../types';
 
-type OpenAPIParameters = Parameters<typeof _convertParametersToJSONSchema>[0];
+type OpenAPIParameters = Parameters<typeof convertParametersToJSONSchema>[0];
 
-function convertParametersToJSONSchema(
+function convertParametersToJsonSchema(
   openApiParameters: OpenAPIParameters,
 ): OpenAPIParametersAsJSONSchema {
-  const parameters = _convertParametersToJSONSchema(openApiParameters);
+  const parameters = convertParametersToJSONSchema(openApiParameters);
 
   // Append "type" prop which "openapi-jsonschema-parameters" seems to omit
   let paramName: keyof OpenAPIParametersAsJSONSchema;
@@ -45,7 +45,7 @@ export function convertOpenApiPathsParameters(schema: JSONSchema): JSONSchema {
         'parameters' in pathSchema ? pathSchema.parameters : [];
 
       if (pathParameters.length) {
-        pathSchema.parameters = convertParametersToJSONSchema(
+        pathSchema.parameters = convertParametersToJsonSchema(
           pathSchema.parameters,
         );
       }
@@ -58,7 +58,7 @@ export function convertOpenApiPathsParameters(schema: JSONSchema): JSONSchema {
         const operationSchema = pathSchema[operation];
         if ('parameters' in operationSchema) {
           // Merge operation and common path parameters
-          operationSchema.parameters = convertParametersToJSONSchema([
+          operationSchema.parameters = convertParametersToJsonSchema([
             ...pathParameters,
             ...operationSchema.parameters,
           ]);

--- a/src/utils/convertOpenApiToJsonSchema.ts
+++ b/src/utils/convertOpenApiToJsonSchema.ts
@@ -1,24 +1,43 @@
+import mapObject from 'map-obj';
 import { fromSchema } from '@openapi-contrib/openapi-schema-to-json-schema';
-import type { OpenApiSchema } from '../types';
+import { isObject } from './';
+import type { OpenApiSchema, JSONSchema } from '../types';
 
-export function convertOpenApiToJsonSchema(schema: OpenApiSchema) {
-  /**
-   * @openapi-contrib/openapi-schema-to-json-schema doesn't convert definitions by default,
-   * Here we convert all direct children of components object:
-   * https://swagger.io/specification/#components-object
-   * https://github.com/openapi-contrib/openapi-schema-to-json-schema#definitionkeywords-array
-   */
-  const definitionKeywords = ['components'];
-
-  if ('components' in schema) {
-    definitionKeywords.push(
-      ...Object.keys(schema.components).map((field) => `components.${field}`),
-    );
+function convertToJsonSchema<Value extends unknown>(
+  value: Value,
+): JSONSchema | Value {
+  if (!isObject(value)) {
+    return value;
   }
 
-  const jsonSchema = fromSchema(schema, {
-    definitionKeywords,
-  });
+  /**
+   * type as array is not a valid OpenAPI value
+   * https://swagger.io/docs/specification/data-models/data-types#mixed-types
+   */
+  if ('type' in value && Array.isArray(value.type)) {
+    return value;
+  }
 
-  return jsonSchema;
+  const schema = fromSchema(value);
+  // $schema is appended by @openapi-contrib/openapi-schema-to-json-schema
+  delete schema.$schema;
+  return schema;
+}
+
+/**
+ * Traverse the openAPI schema tree an brutally try to convert
+ * everything possible to JSON schema. We are probably overdoing since we process any object
+ * @TODO Find a cleaner way to convert to JSON schema all the existing OpenAPI schemas
+ * @NOTE We are currently skipping arrays
+ */
+export function convertOpenApiToJsonSchema(
+  schema: OpenApiSchema,
+): Record<string, unknown> {
+  return mapObject(
+    schema,
+    (key, value) => {
+      return [key, convertToJsonSchema(value)];
+    },
+    { deep: true },
+  );
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -13,6 +13,7 @@ export {
 export { replaceInlinedRefsWithStringPlaceholder } from './makeTsJsonSchema/replaceInlinedRefsWithStringPlaceholder';
 export { replacePlaceholdersWithImportedSchemas } from './makeTsJsonSchema/replacePlaceholdersWithImportedSchemas';
 export { addSchemaToMetaData } from './addSchemaToMetaData';
+export { isObject } from './isObject';
 
 export { clearFolder } from './clearFolder';
 export { makeRelativePath } from './makeRelativePath';

--- a/src/utils/isObject.ts
+++ b/src/utils/isObject.ts
@@ -1,0 +1,5 @@
+export function isObject(
+  value: unknown,
+): value is Record<string | symbol, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/utils/makeTsJsonSchema/getRef.ts
+++ b/src/utils/makeTsJsonSchema/getRef.ts
@@ -1,8 +1,5 @@
 import { REF_SYMBOL } from '..';
-
-function isObject(value: unknown): value is Record<string | symbol, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
+import { isObject } from '../';
 
 /**
  * Retrieve REF_SYMBOL prop value

--- a/test/fixtures/complex/specs.yaml
+++ b/test/fixtures/complex/specs.yaml
@@ -50,6 +50,12 @@ paths:
                 oneOf:
                   - $ref: '#/components/months/January'
                   - $ref: '#/components/months/February'
+                  - type: integer
+                    nullable: true
+                    enum:
+                      - 1
+                      - 0
+                    description: Inline path schema
 
 servers:
   - url: url

--- a/test/fixtures/paths/specs.yaml
+++ b/test/fixtures/paths/specs.yaml
@@ -1,0 +1,96 @@
+openapi: 3.0.3
+info:
+  title: title
+  description: description
+  version: 1.0.0
+
+paths:
+  /users/{id}:
+    get:
+      tags:
+        - Users
+      summary: Gets a user by ID.
+      description: Get users description
+      operationId: getUserById
+      parameters:
+        - name: id
+          in: path
+          description: User ID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+    post:
+      tags:
+        - Users
+      summary: Posts a user by ID.
+      description: Post users description
+      operationId: postUserById
+      parameters:
+        - name: id
+          in: path
+          description: User ID
+          required: true
+          schema:
+            type: integer
+
+      requestBody:
+        description: Body description
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+          application/xml:
+            # Inlining User definition to test conversion to JSON schema
+            schema:
+              type: object
+              nullable: true
+              properties:
+                id:
+                  type: integer
+                name:
+                  type: string
+              required:
+                - id
+                - name
+          text/plain:
+            schema:
+              type: string
+
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              # Inlining User definition to test conversion to JSON schema
+              schema:
+                type: object
+                nullable: true
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                required:
+                  - id
+                  - name
+components:
+  schemas:
+    User:
+      type: object
+      nullable: true
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+      required:
+        - id
+        - name

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -72,6 +72,11 @@ describe('openapiToTsJsonSchema', () => {
                         },
                       },
                     },
+                    {
+                      description: 'Inline path schema',
+                      type: ['integer', 'null'],
+                      enum: [1, 0, null],
+                    },
                   ],
                 },
               },

--- a/test/paths-parameters.test.ts
+++ b/test/paths-parameters.test.ts
@@ -7,7 +7,7 @@ describe('OpenAPI paths parameters', () => {
   it('Transforms parameters array into valid JSON schema', async () => {
     const { outputPath } = await openapiToTsJsonSchema({
       openApiSchema: path.resolve(fixtures, 'paths-parameters/specs.yaml'),
-      outputPath: makeTestOutputPath('parameters'),
+      outputPath: makeTestOutputPath('paths-parameters'),
       definitionPathsToGenerateFrom: ['paths'],
       silent: true,
     });

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -1,0 +1,117 @@
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+import { fixtures, makeTestOutputPath } from './test-utils';
+import { openapiToTsJsonSchema } from '../src';
+
+describe('OpenAPI paths', () => {
+  it('Generates expected paths schemas', async () => {
+    const { outputPath } = await openapiToTsJsonSchema({
+      openApiSchema: path.resolve(fixtures, 'paths/specs.yaml'),
+      outputPath: makeTestOutputPath('paths'),
+      definitionPathsToGenerateFrom: ['paths'],
+      silent: true,
+    });
+
+    const pathSchema = await import(
+      path.resolve(outputPath, 'paths/users|{id}')
+    );
+
+    const componentsSchemasUser = {
+      type: ['object', 'null'],
+      properties: {
+        id: {
+          type: 'integer',
+        },
+        name: {
+          type: 'string',
+        },
+      },
+      required: ['id', 'name'],
+    };
+
+    expect(pathSchema.default).toEqual({
+      get: {
+        tags: ['Users'],
+        summary: 'Gets a user by ID.',
+        description: 'Get users description',
+        operationId: 'getUserById',
+        parameters: {
+          path: {
+            properties: {
+              id: {
+                type: 'integer',
+              },
+            },
+            required: ['id'],
+            type: 'object',
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Successful operation',
+            content: {
+              'application/json': {
+                schema: componentsSchemasUser,
+              },
+            },
+          },
+        },
+      },
+      post: {
+        tags: ['Users'],
+        summary: 'Posts a user by ID.',
+        description: 'Post users description',
+        operationId: 'postUserById',
+        parameters: {
+          path: {
+            properties: {
+              id: {
+                type: 'integer',
+              },
+            },
+            required: ['id'],
+            type: 'object',
+          },
+        },
+        requestBody: {
+          description: 'Body description',
+          required: true,
+          content: {
+            'application/json': {
+              schema: componentsSchemasUser,
+            },
+            'application/xml': {
+              schema: {
+                type: ['object', 'null'],
+                properties: {
+                  id: {
+                    type: 'integer',
+                  },
+                  name: {
+                    type: 'string',
+                  },
+                },
+                required: ['id', 'name'],
+              },
+            },
+            'text/plain': {
+              schema: {
+                type: 'string',
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Successful operation',
+            content: {
+              'application/json': {
+                schema: componentsSchemasUser,
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+});

--- a/test/refHandling-import.test.ts
+++ b/test/refHandling-import.test.ts
@@ -63,6 +63,11 @@ describe('refHandling option === "import"', () => {
                           },
                         },
                       },
+                      {
+                        description: 'Inline path schema',
+                        type: ['integer', 'null'],
+                        enum: [1, 0, null],
+                      },
                     ],
                   },
                 },

--- a/test/refHandling-import.test.ts
+++ b/test/refHandling-import.test.ts
@@ -97,7 +97,15 @@ describe('refHandling option === "import"', () => {
                 content: {
                   "application/json": {
                     schema: {
-                      oneOf: [componentsMonthsJanuary, componentsMonthsFebruary],
+                      oneOf: [
+                        componentsMonthsJanuary,
+                        componentsMonthsFebruary,
+                        {
+                          type: ["integer", "null"],
+                          enum: [1, 0, null],
+                          description: "Inline path schema",
+                        },
+                      ],
                     },
                   },
                 },
@@ -106,7 +114,7 @@ describe('refHandling option === "import"', () => {
           },
         } as const;`);
 
-      expect(actualPath1File).toMatch(expectedPath1File);
+      expect(actualPath1File).toEqual(expectedPath1File);
     });
   });
 

--- a/test/refHandling-keep.test.ts
+++ b/test/refHandling-keep.test.ts
@@ -63,7 +63,12 @@ describe('refHandling option === "keep"', () => {
                   schema: {
                     oneOf: [
                       { $ref: "#/components/months/January" },
-                      { $ref: "#/components/months/February" }
+                      { $ref: "#/components/months/February" },
+                      {
+                        type: ['integer', 'null'],
+                        enum: [1, 0, null],
+                        description: 'Inline path schema'
+                      },
                     ],
                   },
                 },

--- a/test/refHandling-keep.test.ts
+++ b/test/refHandling-keep.test.ts
@@ -29,6 +29,11 @@ describe('refHandling option === "keep"', () => {
                   oneOf: [
                     { $ref: '#/components/months/January' },
                     { $ref: '#/components/months/February' },
+                    {
+                      description: 'Inline path schema',
+                      type: ['integer', 'null'],
+                      enum: [1, 0, null],
+                    },
                   ],
                 },
               },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

Inlined schemas defined out of `component` prop not being converted to JSON schema

## What is the new behaviour?

Parse the whole OpenAPI tree converting all the existing OpenApi definitions found

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
