### PR TITLE
fix: use "_" as path separator

### DIFF
--- a/.changeset/afraid-laws-breathe.md
+++ b/.changeset/afraid-laws-breathe.md
@@ -1,0 +1,5 @@
+---
+"openapi-ts-json-schema": minor
+---
+
+use `_` as path separator to support Windows OS

--- a/examples/fastify-integration-plugin/definitions/petstore/schemas-autogenerated/paths/pets.ts
+++ b/examples/fastify-integration-plugin/definitions/petstore/schemas-autogenerated/paths/pets.ts
@@ -10,9 +10,11 @@ export default {
             type: "integer",
             maximum: 100,
             format: "int32",
+            minimum: -2147483648,
           },
         },
         required: [],
+        type: "object",
       },
     },
     responses: {

--- a/examples/fastify-integration-plugin/definitions/petstore/schemas-autogenerated/paths/pets_{petId}.ts
+++ b/examples/fastify-integration-plugin/definitions/petstore/schemas-autogenerated/paths/pets_{petId}.ts
@@ -11,6 +11,7 @@ export default {
           },
         },
         required: ["petId"],
+        type: "object",
       },
     },
     responses: {

--- a/src/utils/addSchemaToMetaData.ts
+++ b/src/utils/addSchemaToMetaData.ts
@@ -1,8 +1,7 @@
 import path from 'node:path';
 // @ts-expect-error no type defs for namify
 import namify from 'namify';
-import filenamify from 'filenamify';
-import { refToPath } from '.';
+import { refToPath, filenamify } from '.';
 import type { SchemaMetaDataMap, SchemaMetaData, JSONSchema } from '../types';
 
 /*
@@ -27,7 +26,7 @@ export function addSchemaToMetaData({
     const { schemaRelativeDirName, schemaName, schemaRelativePath } =
       refToPath(ref);
     const schemaAbsoluteDirName = path.join(outputPath, schemaRelativeDirName);
-    const schemaFileName = filenamify(schemaName, { replacement: '|' });
+    const schemaFileName = filenamify(schemaName);
     const schemaAbsoluteImportPath = path.join(
       schemaAbsoluteDirName,
       schemaFileName,

--- a/src/utils/filenamify.ts
+++ b/src/utils/filenamify.ts
@@ -1,0 +1,16 @@
+import _filenamify from 'filenamify';
+
+/**
+ * Replace "/" occurrences with "_"
+ * and any other file path unsafe character with "!"
+ */
+
+const TRAILING_SLASH_REGEX = /^\//;
+export function filenamify(name: string): string {
+  return _filenamify(
+    name.replace(TRAILING_SLASH_REGEX, '').replaceAll('/', '_'),
+    {
+      replacement: '!',
+    },
+  );
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -14,6 +14,7 @@ export { replaceInlinedRefsWithStringPlaceholder } from './makeTsJsonSchema/repl
 export { replacePlaceholdersWithImportedSchemas } from './makeTsJsonSchema/replacePlaceholdersWithImportedSchemas';
 export { addSchemaToMetaData } from './addSchemaToMetaData';
 export { isObject } from './isObject';
+export { filenamify } from './filenamify';
 
 export { clearFolder } from './clearFolder';
 export { makeRelativePath } from './makeRelativePath';

--- a/src/utils/pathToRef.ts
+++ b/src/utils/pathToRef.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import filenamify from 'filenamify';
+import { filenamify } from './';
 
 /**
  * Generate a local OpenAPI ref from a relative path and a schema name
@@ -15,7 +15,7 @@ export function pathToRef({
     '#/' +
     path.join(
       schemaRelativeDirName.replaceAll('.', '/'),
-      filenamify(schemaName, { replacement: '|' }),
+      filenamify(schemaName),
     )
   );
 }

--- a/test/dereferencing.test.ts
+++ b/test/dereferencing.test.ts
@@ -35,7 +35,7 @@ describe('Dereferencing', () => {
     });
 
     const pathsSchema = await import(
-      path.resolve(outputPath, 'paths/v1|path-1')
+      path.resolve(outputPath, 'paths/v1_path-1')
     );
 
     expect(

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -21,7 +21,7 @@ describe('openapiToTsJsonSchema', () => {
     );
 
     // definition paths get escaped
-    const path1 = await import(path.resolve(outputPath, 'paths/v1|path-1'));
+    const path1 = await import(path.resolve(outputPath, 'paths/v1_path-1'));
 
     expect(januarySchema.default).toEqual({
       description: 'January description',

--- a/test/paths-parameters.test.ts
+++ b/test/paths-parameters.test.ts
@@ -13,7 +13,7 @@ describe('OpenAPI paths parameters', () => {
     });
 
     const pathSchema = await import(
-      path.resolve(outputPath, 'paths/v1|path-1')
+      path.resolve(outputPath, 'paths/v1_path-1')
     );
 
     expect(pathSchema.default).toEqual({

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -13,7 +13,7 @@ describe('OpenAPI paths', () => {
     });
 
     const pathSchema = await import(
-      path.resolve(outputPath, 'paths/users|{id}')
+      path.resolve(outputPath, 'paths/users_{id}')
     );
 
     const componentsSchemasUser = {

--- a/test/refHandling-import.test.ts
+++ b/test/refHandling-import.test.ts
@@ -29,7 +29,7 @@ describe('refHandling option === "import"', () => {
         refHandling: 'import',
       });
 
-      const path1 = await import(path.resolve(outputPath, 'paths/v1|path-1'));
+      const path1 = await import(path.resolve(outputPath, 'paths/v1_path-1'));
 
       // Expectations against parsed root schema
       expect(path1.default).toEqual({
@@ -79,7 +79,7 @@ describe('refHandling option === "import"', () => {
 
       // Expectations against actual root schema file (make sure it actually imports refs :))
       const actualPath1File = await fs.readFile(
-        path.resolve(outputPath, 'paths/v1|path-1.ts'),
+        path.resolve(outputPath, 'paths/v1_path-1.ts'),
         {
           encoding: 'utf8',
         },

--- a/test/refHandling-keep.test.ts
+++ b/test/refHandling-keep.test.ts
@@ -15,7 +15,7 @@ describe('refHandling option === "keep"', () => {
       refHandling: 'keep',
     });
 
-    const path1 = await import(path.resolve(outputPath, 'paths/v1|path-1'));
+    const path1 = await import(path.resolve(outputPath, 'paths/v1_path-1'));
 
     // Expectations against parsed root schema
     expect(path1.default).toEqual({
@@ -45,7 +45,7 @@ describe('refHandling option === "keep"', () => {
 
     // Expectations against actual root schema file
     const actualPath1File = await fs.readFile(
-      path.resolve(outputPath, 'paths/v1|path-1.ts'),
+      path.resolve(outputPath, 'paths/v1_path-1.ts'),
       {
         encoding: 'utf8',
       },

--- a/test/schemaPatcher.test.ts
+++ b/test/schemaPatcher.test.ts
@@ -32,7 +32,7 @@ describe('"schemaPatcher" option', () => {
 
     // Testing deep nested props being patched, too
     const pathSchema = await import(
-      path.resolve(outputPath, 'paths/v1|path-1')
+      path.resolve(outputPath, 'paths/v1_path-1')
     );
 
     expect(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## What is the current behaviour?

#188

## What is the new behaviour?

Use `_` as path separator

## Does this PR introduce a breaking change?

Yes, filenames (especially path schemas) containing special characters could be generated under a different path. Eg: `|` occurrences replaced by `_`.

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
