### PR TITLE
refactor: rename metadata props

### DIFF
--- a/.changeset/afraid-laws-breathe.md
+++ b/.changeset/afraid-laws-breathe.md
@@ -2,4 +2,4 @@
 "openapi-ts-json-schema": minor
 ---
 
-use `_` as path separator to support Windows OS
+Use `_` as path separator to support Windows OS

--- a/.changeset/cool-insects-boil.md
+++ b/.changeset/cool-insects-boil.md
@@ -1,0 +1,5 @@
+---
+"openapi-ts-json-schema": minor
+---
+
+Metadata props renamed (see documentation)

--- a/.changeset/sixty-ears-cheat.md
+++ b/.changeset/sixty-ears-cheat.md
@@ -2,4 +2,4 @@
 "openapi-ts-json-schema": patch
 ---
 
-Convert to JSON schema definitions inlined in other places then components prop
+Convert inlined definitions in other places then components prop

--- a/.changeset/wicked-carrots-mate.md
+++ b/.changeset/wicked-carrots-mate.md
@@ -2,4 +2,4 @@
 "openapi-ts-json-schema": minor
 ---
 
-Remove `schemaFileName` meta data prop
+`schemaFileName` metadata prop removed

--- a/README.md
+++ b/README.md
@@ -113,20 +113,20 @@ Beside generating the expected schema files under `outputPath`, `openapiToTsJson
       // OpenAPI ref. Eg: "#/components/schemas/MySchema"
       string,
       {
-        schemaId: string;
+        id: string;
         // JSON schema Compound Schema Document `$id`. Eg: `"/components/schemas/MySchema"`
-        schemaUniqueName: string;
+        uniqueName: string;
         // Unique JavaScript identifier used as import name. Eg: `"componentsSchemasMySchema"`
         originalSchema: JSONSchema | string;
         // Original dereferenced JSON schema
         isRef: boolean;
         // True if schemas is used as a `$ref`
 
-        schemaAbsoluteDirName: string;
+        absoluteDirName: string;
         // Absolute path pointing to schema folder (posix or win32). Eg: `"Users/username/output/path/components/schemas"`
-        schemaAbsolutePath: string;
+        absolutePath: string;
         // Absolute path pointing to schema file (posix or win32). Eg: `"Users/username/output/path/components/schemas/MySchema.ts"`
-        schemaAbsoluteImportPath: string;
+        absoluteImportPath: string;
         // Absolute import path (posix or win32, without extension). Eg: `"Users/username/output/path/components/schemas/MySchema"`
       }
     >;

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -30,9 +30,9 @@ Please consider that `@fastify/swagger` currently comes with some limitations. E
 
 ### Options
 
-| Property                | Type                                         | Description                                                                                                                                                                                  | Default |
-| ----------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| **sharedSchemasFilter** | `({schemaId}: {schemaId:string}) => boolean` | Expose a `sharedSchemas` array with extra user-selected schemas to be registered with `fastify.addSchema`. Provided function is used to filter all available non-$ref generated JSON schemas | -       |
+| Property                | Type                             | Description                                                                                                                                                                                  | Default |
+| ----------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| **sharedSchemasFilter** | `({id}: {id:string}) => boolean` | Expose a `sharedSchemas` array with extra user-selected schemas to be registered with `fastify.addSchema`. Provided function is used to filter all available non-$ref generated JSON schemas | -       |
 
 ### Example
 
@@ -52,8 +52,7 @@ await openapiToTsJsonSchema({
   plugins: [
     fastifyIntegrationPlugin({
       // Optional
-      sharedSchemasFilter: ({ schemaId }) =>
-        schemaId.startsWith('/components/schemas'),
+      sharedSchemasFilter: ({ id }) => id.startsWith('/components/schemas'),
     }),
   ],
 });

--- a/examples/fastify-integration-plugin/scripts/generate-schemas.ts
+++ b/examples/fastify-integration-plugin/scripts/generate-schemas.ts
@@ -11,8 +11,7 @@ async function generate() {
     refHandling: 'keep',
     plugins: [
       fastifyIntegrationPlugin({
-        sharedSchemasFilter: ({ schemaId }) =>
-          schemaId.startsWith('/components/schemas'),
+        sharedSchemasFilter: ({ id }) => id.startsWith('/components/schemas'),
       }),
     ],
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,24 +11,24 @@ import type {
 
 /**
  * Meta data for representing a specific openApi definition
- * @property `schemaId` - JSON schema Compound Schema Document `$id`. Eg `"/components/schemas/MySchema"`
+ * @property `id` - JSON schema Compound Schema Document `$id`. Eg `"/components/schemas/MySchema"`
  * @property `isRef` - True if schemas is used as `$ref`
- * @property `schemaUniqueName` - Unique JavaScript identifier used as import name. Eg: `"componentsSchemasMySchema"`
+ * @property `uniqueName` - Unique JavaScript identifier used as import name. Eg: `"componentsSchemasMySchema"`
  * @property `originalSchema` - Original dereferenced JSON schema
  *
- * @property `schemaAbsoluteDirName` - Absolute path pointing to schema folder (posix or win32). Eg: `"Users/username/output/path/components/schemas"`
- * @property `schemaAbsolutePath` - Absolute path pointing to schema file (posix or win32). Eg: `"Users/username/output/path/components/schemas/MySchema.ts"`
- * @property `schemaAbsoluteImportPath` - Absolute import path (posix or win32, without extension). Eg: `"Users/username/output/path/components/schemas/MySchema"`
+ * @property `absoluteDirName` - Absolute path pointing to schema folder (posix or win32). Eg: `"Users/username/output/path/components/schemas"`
+ * @property `absolutePath` - Absolute path pointing to schema file (posix or win32). Eg: `"Users/username/output/path/components/schemas/MySchema.ts"`
+ * @property `absoluteImportPath` - Absolute import path (posix or win32, without extension). Eg: `"Users/username/output/path/components/schemas/MySchema"`
  */
 export type SchemaMetaData = {
-  schemaId: string;
+  id: string;
   isRef: boolean;
-  schemaUniqueName: string;
+  uniqueName: string;
   originalSchema: JSONSchema;
 
-  schemaAbsoluteDirName: string;
-  schemaAbsolutePath: string;
-  schemaAbsoluteImportPath: string;
+  absoluteDirName: string;
+  absolutePath: string;
+  absoluteImportPath: string;
 };
 
 export type SchemaMetaDataMap = Map<

--- a/src/utils/addSchemaToMetaData.ts
+++ b/src/utils/addSchemaToMetaData.ts
@@ -25,22 +25,19 @@ export function addSchemaToMetaData({
   if (!schemaMetaDataMap.has(ref)) {
     const refPath = parseRef(ref);
     const { schemaRelativeDirName, schemaName } = refToPath(ref);
-    const schemaAbsoluteDirName = path.join(outputPath, schemaRelativeDirName);
+    const absoluteDirName = path.join(outputPath, schemaRelativeDirName);
     const schemaFileName = filenamify(schemaName);
-    const schemaAbsoluteImportPath = path.join(
-      schemaAbsoluteDirName,
-      schemaFileName,
-    );
+    const absoluteImportPath = path.join(absoluteDirName, schemaFileName);
 
     const metaInfo: SchemaMetaData = {
-      schemaId: `/${refPath}`,
-      schemaUniqueName: namify(refPath),
+      id: `/${refPath}`,
+      uniqueName: namify(refPath),
       isRef,
       originalSchema: schema,
 
-      schemaAbsoluteDirName,
-      schemaAbsoluteImportPath,
-      schemaAbsolutePath: schemaAbsoluteImportPath + '.ts',
+      absoluteDirName,
+      absoluteImportPath,
+      absolutePath: absoluteImportPath + '.ts',
     };
 
     schemaMetaDataMap.set(ref, metaInfo);

--- a/src/utils/makeRelativeModulePath.ts
+++ b/src/utils/makeRelativeModulePath.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 
 /**
  * Evaluate the relative module path from/to 2 absolute paths.
- * Accepts posix and win32 absolute urls and return a relative modules path (""./foo/bar")
+ * Accepts posix and win32 absolute urls and return a relative modules path ("./foo/bar")
  */
 export function makeRelativeModulePath({
   fromDirectory,
@@ -12,6 +12,6 @@ export function makeRelativeModulePath({
   to: string;
 }): string {
   return (
-    './' + path.relative(fromDirectory, to).split(path.sep).join(path.posix.sep)
+    './' + path.relative(fromDirectory, to).replaceAll(path.sep, path.posix.sep)
   );
 }

--- a/src/utils/makeTsJsonSchema/index.ts
+++ b/src/utils/makeTsJsonSchema/index.ts
@@ -22,7 +22,7 @@ export async function makeTsJsonSchema({
   refHandling: 'inline' | 'import' | 'keep';
   schemaPatcher?: SchemaPatcher;
 }): Promise<string> {
-  const { originalSchema, schemaAbsoluteDirName } = metaData;
+  const { originalSchema, absoluteDirName } = metaData;
 
   // "inline" refHandling doesn't need replacing inlined refs
   const schemaWithPlaceholders =
@@ -59,7 +59,7 @@ export async function makeTsJsonSchema({
   if (refHandling === 'import') {
     tsSchema = replacePlaceholdersWithImportedSchemas({
       schemaAsText: tsSchema,
-      schemaAbsoluteDirName,
+      absoluteDirName,
       schemaMetaDataMap,
     });
   }

--- a/src/utils/makeTsJsonSchema/replacePlaceholdersWithImportedSchemas.ts
+++ b/src/utils/makeTsJsonSchema/replacePlaceholdersWithImportedSchemas.ts
@@ -6,11 +6,11 @@ import type { SchemaMetaDataMap } from '../../types';
  */
 export function replacePlaceholdersWithImportedSchemas({
   schemaAsText,
-  schemaAbsoluteDirName,
+  absoluteDirName,
   schemaMetaDataMap,
 }: {
   schemaAsText: string;
-  schemaAbsoluteDirName: string;
+  absoluteDirName: string;
   schemaMetaDataMap: SchemaMetaDataMap;
 }): string {
   const importStatements = new Set<string>();
@@ -29,17 +29,17 @@ export function replacePlaceholdersWithImportedSchemas({
 
     // Evaluate imported schema relative path from current schema file
     const importedSchemaRelativePath = makeRelativeModulePath({
-      fromDirectory: schemaAbsoluteDirName,
-      to: importedSchema.schemaAbsoluteImportPath,
+      fromDirectory: absoluteDirName,
+      to: importedSchema.absoluteImportPath,
     });
 
-    const { schemaUniqueName } = importedSchema;
+    const { uniqueName } = importedSchema;
 
     importStatements.add(
-      `import ${schemaUniqueName} from "${importedSchemaRelativePath}"`,
+      `import ${uniqueName} from "${importedSchemaRelativePath}"`,
     );
 
-    return schemaUniqueName;
+    return uniqueName;
   });
 
   if (importStatements.size > 0) {

--- a/src/utils/makeTsJsonSchemaFiles.ts
+++ b/src/utils/makeTsJsonSchemaFiles.ts
@@ -21,7 +21,7 @@ export async function makeTsJsonSchemaFiles({
       schemaPatcher,
     });
 
-    const { schemaAbsolutePath } = metaData;
-    await saveFile({ path: [schemaAbsolutePath], data: tsSchema });
+    const { absolutePath } = metaData;
+    await saveFile({ path: [absolutePath], data: tsSchema });
   }
 }

--- a/src/utils/pathToRef.ts
+++ b/src/utils/pathToRef.ts
@@ -16,6 +16,7 @@ export function pathToRef({
     '#/' +
     path
       .normalize(schemaRelativeDirName)
+      // Supporting definitionPathsToGenerateFrom dot notation
       .replaceAll('.', '/')
       .replaceAll('\\', '/')
       .replace(TRALING_SLASH_REGEX, '') +

--- a/test/metaData.test.ts
+++ b/test/metaData.test.ts
@@ -28,42 +28,50 @@ describe('Returned "metaData"', async () => {
     }
 
     const expectedAnswerMetaData: SchemaMetaData = {
-      schemaId: '/components/schemas/Answer',
-      schemaUniqueName: 'componentsSchemasAnswer',
+      id: '/components/schemas/Answer',
+      uniqueName: 'componentsSchemasAnswer',
       originalSchema: expect.any(Object),
       isRef: true,
 
-      schemaAbsoluteDirName: `${outputPath}/components/schemas`.replaceAll(
+      absoluteDirName: `${outputPath}/components/schemas`.replaceAll(
         '/',
         path.sep,
       ),
-      schemaAbsolutePath:
-        `${outputPath}/components/schemas/Answer.ts`.replaceAll('/', path.sep),
-      schemaAbsoluteImportPath:
-        `${outputPath}/components/schemas/Answer`.replaceAll('/', path.sep),
+      absolutePath: `${outputPath}/components/schemas/Answer.ts`.replaceAll(
+        '/',
+        path.sep,
+      ),
+      absoluteImportPath: `${outputPath}/components/schemas/Answer`.replaceAll(
+        '/',
+        path.sep,
+      ),
     };
 
     const expectedJanuaryMetaData: SchemaMetaData = {
-      schemaId: '/components/months/January',
-      schemaUniqueName: 'componentsMonthsJanuary',
+      id: '/components/months/January',
+      uniqueName: 'componentsMonthsJanuary',
       originalSchema: expect.any(Object),
       isRef: false,
 
-      schemaAbsoluteDirName: `${outputPath}/components/months`.replaceAll(
+      absoluteDirName: `${outputPath}/components/months`.replaceAll(
         '/',
         path.sep,
       ),
-      schemaAbsolutePath:
-        `${outputPath}/components/months/January.ts`.replaceAll('/', path.sep),
-      schemaAbsoluteImportPath:
-        `${outputPath}/components/months/January`.replaceAll('/', path.sep),
+      absolutePath: `${outputPath}/components/months/January.ts`.replaceAll(
+        '/',
+        path.sep,
+      ),
+      absoluteImportPath: `${outputPath}/components/months/January`.replaceAll(
+        '/',
+        path.sep,
+      ),
     };
 
     expect(answerMetaData).toEqual(expectedAnswerMetaData);
     expect(januaryMetaData).toEqual(expectedJanuaryMetaData);
 
-    // schemaAbsolutePath matches generated schema path
-    expect(fs.existsSync(answerMetaData.schemaAbsolutePath)).toBe(true);
-    expect(fs.existsSync(januaryMetaData.schemaAbsolutePath)).toBe(true);
+    // absolutePath matches generated schema path
+    expect(fs.existsSync(answerMetaData.absolutePath)).toBe(true);
+    expect(fs.existsSync(januaryMetaData.absolutePath)).toBe(true);
   });
 });

--- a/test/plugins/fastifyIntegrationPlugin.test.ts
+++ b/test/plugins/fastifyIntegrationPlugin.test.ts
@@ -96,8 +96,8 @@ describe('fastifyIntegration plugin', () => {
         refHandling: 'keep',
         plugins: [
           fastifyIntegrationPlugin({
-            sharedSchemasFilter: ({ schemaId }) =>
-              schemaId.startsWith('/components/months'),
+            sharedSchemasFilter: ({ id }) =>
+              id.startsWith('/components/months'),
           }),
         ],
         silent: true,

--- a/test/unit/addSchemaToMetaData.test.ts
+++ b/test/unit/addSchemaToMetaData.test.ts
@@ -25,19 +25,21 @@ describe('addSchemaToMetaData', () => {
 
     const actual = schemaMetaDataMap.get(ref);
     const expected: SchemaMetaData = {
-      schemaId: '/components/schemas/Foo',
-      schemaUniqueName: 'componentsSchemasFoo',
+      id: '/components/schemas/Foo',
+      uniqueName: 'componentsSchemasFoo',
       isRef: true,
       originalSchema: schema,
 
-      schemaAbsoluteDirName:
-        '/absolute/output/path/components/schemas'.replaceAll('/', path.sep),
-      schemaAbsoluteImportPath:
+      absoluteDirName: '/absolute/output/path/components/schemas'.replaceAll(
+        '/',
+        path.sep,
+      ),
+      absoluteImportPath:
         '/absolute/output/path/components/schemas/Foo'.replaceAll(
           '/',
           path.sep,
         ),
-      schemaAbsolutePath:
+      absolutePath:
         '/absolute/output/path/components/schemas/Foo.ts'.replaceAll(
           '/',
           path.sep,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor (in preparation to upcoming v1 release)

## What is the new behaviour?

`metadata` props renamed (see documentation)

## Does this PR introduce a breaking change?

Yes, external integration relying on `metadata` should be updated accordingly

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
