### PR TITLE
fix: entities conversion with type prop

### DIFF
--- a/.changeset/sour-baboons-check.md
+++ b/.changeset/sour-baboons-check.md
@@ -1,0 +1,5 @@
+---
+"openapi-ts-json-schema": patch
+---
+
+Fix JSON Schema conversions on objects with `type` prop

--- a/src/utils/convertOpenApiToJsonSchema.ts
+++ b/src/utils/convertOpenApiToJsonSchema.ts
@@ -18,30 +18,23 @@ function convertToJsonSchema<Value extends unknown>(
     return value;
   }
 
-  /**
-   * type as array is not a valid OpenAPI value
-   * https://swagger.io/docs/specification/data-models/data-types#mixed-types
-   */
-  if (Array.isArray(value.type)) {
-    return value;
-  }
+  if ('type' in value) {
+    /**
+     * Skip entities with "type" props defined and not a string
+     * (They should have already been converted, anyway)
+     * https://github.com/toomuchdesign/openapi-ts-json-schema/issues/211
+     */
+    if (typeof value.type !== 'string') {
+      return value;
+    }
 
-  /**
-   * Skip parameter objects
-   */
-  if ('in' in value) {
-    return value;
-  }
-
-  /**
-   * Skip security scheme object definitions
-   * https://swagger.io/specification/#security-scheme-object
-   */
-  if (
-    typeof value.type === 'string' &&
-    SECURITY_SCHEME_OBJECT_TYPES.includes(value.type)
-  ) {
-    return value;
+    /**
+     * Skip security scheme object definitions
+     * https://swagger.io/specification/#security-scheme-object
+     */
+    if (SECURITY_SCHEME_OBJECT_TYPES.includes(value.type)) {
+      return value;
+    }
   }
 
   const schema = fromSchema(value);

--- a/test/unit/convertOpenApiToJsonSchema.test.ts
+++ b/test/unit/convertOpenApiToJsonSchema.test.ts
@@ -94,5 +94,29 @@ describe('convertOpenApiToJsonSchema', () => {
         expect(actual).toEqual(definition);
       });
     });
+
+    describe('Object with "type" prop (#211)', () => {
+      it('convert object definitions', () => {
+        const actual = convertOpenApiToJsonSchema({
+          type: 'object',
+          properties: {
+            type: { type: 'string', nullable: true },
+            bar: { type: 'string' },
+          },
+          required: ['type', 'bar'],
+        });
+
+        const expected = {
+          type: 'object',
+          properties: {
+            type: { type: ['string', 'null'] },
+            bar: { type: 'string' },
+          },
+          required: ['type', 'bar'],
+        };
+
+        expect(actual).toEqual(expected);
+      });
+    });
   });
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

#211 

## What is the new behaviour?

Do not convert entities with a `type` prop defined and not of type string (since they should be already converted)

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
