### PR TITLE
feat: provide plugins access to options object

### DIFF
--- a/.changeset/tall-phones-fail.md
+++ b/.changeset/tall-phones-fail.md
@@ -1,0 +1,5 @@
+---
+"openapi-ts-json-schema": minor
+---
+
+Provide plugins access to options object

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -69,7 +69,7 @@ import type { Plugin } from 'openapi-ts-json-schema';
 const myPlugin: Plugin<{ optionOne: string; optionTwo: string }> =
   // Factory function with optional options
   ({ optionOne, optionTwo }) =>
-    async ({ outputPath, metaData, utils }) => {
+    async ({ outputPath, metaData, options, utils }) => {
       // Your plugin implementation...
     };
 

--- a/src/plugins/fastifyIntegrationPlugin.ts
+++ b/src/plugins/fastifyIntegrationPlugin.ts
@@ -8,7 +8,18 @@ const fastifyIntegrationPlugin: Plugin<
   } | void
 > =
   ({ sharedSchemasFilter = () => false } = {}) =>
-  async ({ outputPath, metaData, utils }) => {
+  async ({ outputPath, metaData, options, utils }) => {
+    /**
+     * Options validation
+     * Fastify integration plugin is about generating standalone schemas
+     * with "id" and "ref" references
+     */
+    if (options.refHandling !== 'keep') {
+      throw new Error(
+        '[openapi-ts-json-schema]: "options.refHandling" must be set to "keep"',
+      );
+    }
+
     // Derive the schema data necessary to generate the declarations
     const allSchemas = [...metaData.schemas]
       .map(([id, schema]) => schema)

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,16 @@ import type {
   saveFile,
 } from './utils';
 
+export type Options = {
+  openApiSchema: string;
+  definitionPathsToGenerateFrom: string[];
+  schemaPatcher?: SchemaPatcher;
+  outputPath?: string;
+  plugins?: ReturnType<Plugin>[];
+  silent?: boolean;
+  refHandling?: 'inline' | 'import' | 'keep';
+};
+
 /**
  * Meta data for representing a specific openApi definition
  * @property `id` - JSON schema Compound Schema Document `$id`. Eg `"/components/schemas/MySchema"`
@@ -42,6 +52,7 @@ export type ReturnPayload = {
 };
 
 type PluginInput = ReturnPayload & {
+  options: Options;
   utils: {
     makeRelativeModulePath: typeof makeRelativeModulePath;
     formatTypeScript: typeof formatTypeScript;
@@ -49,6 +60,6 @@ type PluginInput = ReturnPayload & {
   };
 };
 
-export type Plugin<Options = void> = (
-  options: Options,
+export type Plugin<PluginOptions = void> = (
+  options: PluginOptions,
 ) => (input: PluginInput) => Promise<void>;

--- a/test/plugins/fastifyIntegrationPlugin/fastifyIntegrationPlugin.test.ts
+++ b/test/plugins/fastifyIntegrationPlugin/fastifyIntegrationPlugin.test.ts
@@ -133,4 +133,19 @@ describe('fastifyIntegration plugin', () => {
       ]);
     });
   });
+
+  it('validates "refHandling" options to be "keep"', async () => {
+    await expect(
+      openapiToTsJsonSchema({
+        openApiSchema: path.resolve(fixtures, 'complex/specs.yaml'),
+        outputPath: makeTestOutputPath('plugin-fastify'),
+        definitionPathsToGenerateFrom: ['components.months'],
+        refHandling: 'import',
+        plugins: [fastifyIntegrationPlugin()],
+        silent: true,
+      }),
+    ).rejects.toThrow(
+      '[openapi-ts-json-schema]: "options.refHandling" must be set to "keep"',
+    );
+  });
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behaviour?

Plugins can't see `openapi-ts-json-schema` options object

## What is the new behaviour?

Plugins called with a new `options` object (which can't be currently mutated)

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
