### PR TITLE
feat: provide plugins access to options object

### DIFF
--- a/.changeset/blue-moles-lie.md
+++ b/.changeset/blue-moles-lie.md
@@ -1,0 +1,5 @@
+---
+"openapi-ts-json-schema": minor
+---
+
+Plugins api changed from a single callback function to 2 optional `onInit` and `beforeGeneration` methods

--- a/.changeset/tall-phones-fail.md
+++ b/.changeset/tall-phones-fail.md
@@ -1,0 +1,5 @@
+---
+"openapi-ts-json-schema": minor
+---
+
+Provide plugins access to options object

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -69,7 +69,7 @@ import type { Plugin } from 'openapi-ts-json-schema';
 const myPlugin: Plugin<{ optionOne: string; optionTwo: string }> =
   // Factory function with optional options
   ({ optionOne, optionTwo }) =>
-    async ({ outputPath, metaData, utils }) => {
+    async ({ outputPath, metaData, options, utils }) => {
       // Your plugin implementation...
     };
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -68,10 +68,14 @@ import type { Plugin } from 'openapi-ts-json-schema';
 // An `openapi-ts-json-schema` consists of a factory function returning an async function
 const myPlugin: Plugin<{ optionOne: string; optionTwo: string }> =
   // Factory function with optional options
-  ({ optionOne, optionTwo }) =>
-    async ({ outputPath, metaData, options, utils }) => {
-      // Your plugin implementation...
+  ({ optionOne, optionTwo }) => ({
+    onInit: async ({ options }) => {
+      // Validate/mutate option values here
     };
+    beforeGeneration: async ({ outputPath, metaData, options, utils }) => {
+      // Generate plugin-specific artifacts
+    };
+  })
 
 export myPlugin;
 ```

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "rimraf ./dist && tsc -p tsconfig.build.json",
     "test": "vitest --config ./vitest.config.mts --dir ./test",
+    "test:build": "npm --prefix ./examples/fastify-integration-plugin run generate-schemas",
     "prepare": "npx simple-git-hooks && npm run test -- --run && npm run source:check && npm run build",
     "tag": "node ./scripts/tag.js",
     "prettier:check": "prettier . --check",

--- a/src/openapiToTsJsonSchema.ts
+++ b/src/openapiToTsJsonSchema.ts
@@ -24,12 +24,22 @@ import type {
 export async function openapiToTsJsonSchema(
   options: Options,
 ): Promise<ReturnPayload> {
+  const { plugins = [] } = options;
+
+  // Execute plugins onInit method
+  for (const { onInit } of plugins) {
+    if (onInit) {
+      await onInit({
+        options,
+      });
+    }
+  }
+
   const {
     openApiSchema: openApiSchemaRelative,
     definitionPathsToGenerateFrom,
     schemaPatcher,
     outputPath: providedOutputPath,
-    plugins = [],
     silent,
     refHandling = 'import',
   } = options;
@@ -151,13 +161,15 @@ export async function openapiToTsJsonSchema(
     metaData: { schemas: schemaMetaDataMap },
   };
 
-  // Execute plugins
-  for (const plugin of plugins) {
-    await plugin({
-      ...returnPayload,
-      options,
-      utils: { makeRelativeModulePath, formatTypeScript, saveFile },
-    });
+  // Execute plugins beforeGeneration method
+  for (const { beforeGeneration } of plugins) {
+    if (beforeGeneration) {
+      await beforeGeneration({
+        ...returnPayload,
+        options,
+        utils: { makeRelativeModulePath, formatTypeScript, saveFile },
+      });
+    }
   }
 
   // Generate schemas

--- a/src/plugins/fastifyIntegrationPlugin.ts
+++ b/src/plugins/fastifyIntegrationPlugin.ts
@@ -8,7 +8,18 @@ const fastifyIntegrationPlugin: Plugin<
   } | void
 > =
   ({ sharedSchemasFilter = () => false } = {}) =>
-  async ({ outputPath, metaData, utils }) => {
+  async ({ outputPath, metaData, options, utils }) => {
+    /**
+     * Options validation
+     * Fastify integration plugin is about generating standalone schemas
+     * with "id" and "ref" references
+     */
+    if (options.refHandling !== 'keep') {
+      throw new Error(
+        '[openapi-ts-json-schema]: "options.refHandling" must be set to "keep"',
+      );
+    }
+
     // Derive the schema data necessary to generate the declarations
     const allSchemas = [...metaData.schemas]
       .map(([id, schema]) => schema)

--- a/src/plugins/fastifyIntegrationPlugin.ts
+++ b/src/plugins/fastifyIntegrationPlugin.ts
@@ -6,9 +6,8 @@ const fastifyIntegrationPlugin: Plugin<
   {
     sharedSchemasFilter?: ({ id }: { id: string }) => boolean;
   } | void
-> =
-  ({ sharedSchemasFilter = () => false } = {}) =>
-  async ({ outputPath, metaData, options, utils }) => {
+> = ({ sharedSchemasFilter = () => false } = {}) => ({
+  onInit: async ({ options }) => {
     /**
      * Options validation
      * Fastify integration plugin is about generating standalone schemas
@@ -19,7 +18,8 @@ const fastifyIntegrationPlugin: Plugin<
         '[openapi-ts-json-schema]: "options.refHandling" must be set to "keep"',
       );
     }
-
+  },
+  beforeGeneration: async ({ outputPath, metaData, options, utils }) => {
     // Derive the schema data necessary to generate the declarations
     const allSchemas = [...metaData.schemas]
       .map(([id, schema]) => schema)
@@ -59,26 +59,26 @@ const fastifyIntegrationPlugin: Plugin<
 
     // RefSchemas type: generate TS tuple TS type containing the types of all $ref JSON schema
     output += `\n\n
-    // Allows json-schema-to-ts to hydrate $refs via the "references" option
-    export type RefSchemas = [
-      ${refSchemas
-        .map((schema) => `typeof ${schema.uniqueName}WithId`)
-        .join(',')}
-    ];`;
+      // Allows json-schema-to-ts to hydrate $refs via the "references" option
+      export type RefSchemas = [
+        ${refSchemas
+          .map((schema) => `typeof ${schema.uniqueName}WithId`)
+          .join(',')}
+      ];`;
 
     // refSchemas: generate an array of all $ref JSON schema to be registered with `fastify.addSchema`
     output += `\n\n
-    // $ref JSON schemas to be registered with "fastify.addSchema"
-    export const refSchemas = [
-      ${refSchemas.map((schema) => `${schema.uniqueName}WithId`).join(',')}
-    ];`;
+      // $ref JSON schemas to be registered with "fastify.addSchema"
+      export const refSchemas = [
+        ${refSchemas.map((schema) => `${schema.uniqueName}WithId`).join(',')}
+      ];`;
 
     // sharedSchemas: generate an array of user-defined schemas to be registered with `fastify.addSchema`
     output += `\n\n
-    // Extra JSON schemas to be registered with "fastify.addSchema"
-    export const sharedSchemas = [
-      ${sharedSchemas.map((schema) => `${schema.uniqueName}WithId`).join(',')}
-    ];`;
+      // Extra JSON schemas to be registered with "fastify.addSchema"
+      export const sharedSchemas = [
+        ${sharedSchemas.map((schema) => `${schema.uniqueName}WithId`).join(',')}
+      ];`;
 
     // Format and save file
     const formattedOutput = await utils.formatTypeScript(output);
@@ -86,6 +86,7 @@ const fastifyIntegrationPlugin: Plugin<
       path: [outputPath, OUTPUT_FILE_NAME],
       data: formattedOutput,
     });
-  };
+  },
+});
 
 export default fastifyIntegrationPlugin;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,16 @@ import type {
   saveFile,
 } from './utils';
 
+export type Options = {
+  openApiSchema: string;
+  definitionPathsToGenerateFrom: string[];
+  schemaPatcher?: SchemaPatcher;
+  outputPath?: string;
+  plugins?: ReturnType<Plugin>[];
+  silent?: boolean;
+  refHandling?: 'inline' | 'import' | 'keep';
+};
+
 /**
  * Meta data for representing a specific openApi definition
  * @property `id` - JSON schema Compound Schema Document `$id`. Eg `"/components/schemas/MySchema"`
@@ -42,6 +52,7 @@ export type ReturnPayload = {
 };
 
 type PluginInput = ReturnPayload & {
+  options: Options;
   utils: {
     makeRelativeModulePath: typeof makeRelativeModulePath;
     formatTypeScript: typeof formatTypeScript;
@@ -49,6 +60,6 @@ type PluginInput = ReturnPayload & {
   };
 };
 
-export type Plugin<Options = void> = (
-  options: Options,
+export type Plugin<PluginOptions = void> = (
+  options: PluginOptions,
 ) => (input: PluginInput) => Promise<void>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,11 @@ export type ReturnPayload = {
   metaData: { schemas: SchemaMetaDataMap };
 };
 
-type PluginInput = ReturnPayload & {
+type OnInitInput = {
+  options: Options;
+};
+
+type BeforeGenerationInput = ReturnPayload & {
   options: Options;
   utils: {
     makeRelativeModulePath: typeof makeRelativeModulePath;
@@ -60,6 +64,7 @@ type PluginInput = ReturnPayload & {
   };
 };
 
-export type Plugin<PluginOptions = void> = (
-  options: PluginOptions,
-) => (input: PluginInput) => Promise<void>;
+export type Plugin<PluginOptions = void> = (options: PluginOptions) => {
+  onInit?: (input: OnInitInput) => Promise<void>;
+  beforeGeneration?: (input: BeforeGenerationInput) => Promise<void>;
+};

--- a/test/plugins/fastifyIntegrationPlugin/fastifyIntegrationPlugin.test.ts
+++ b/test/plugins/fastifyIntegrationPlugin/fastifyIntegrationPlugin.test.ts
@@ -133,4 +133,19 @@ describe('fastifyIntegration plugin', () => {
       ]);
     });
   });
+
+  it('validates "refHandling" options to be "keep"', async () => {
+    await expect(
+      openapiToTsJsonSchema({
+        openApiSchema: path.resolve(fixtures, 'complex/specs.yaml'),
+        outputPath: makeTestOutputPath('plugin-fastify'),
+        definitionPathsToGenerateFrom: ['components.months'],
+        refHandling: 'import',
+        plugins: [fastifyIntegrationPlugin()],
+        silent: true,
+      }),
+    ).rejects.toThrow(
+      '[openapi-ts-json-schema]: "options.refHandling" must be set to "keep"',
+    );
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "noErrorTruncation": true
+    "noErrorTruncation": true,
+    "noUncheckedIndexedAccess": true
   },
   "exclude": ["./dist"]
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the current behaviour?

Plugins cannot modify provided `openapi-ts-json-schema` options

## What is the new behaviour?

Plugins API reviewed to return 2 callbacks:
- `onInit` (where options can be mutated on the fly)
- `beforeGeneration` ()

## Does this PR introduce a breaking change?

Yes. Plugin should be definined as:

Before:

```ts
const myPlugin: Plugin<{ optionOne: string; optionTwo: string }> =
  // Factory function with optional options
  ({ optionOne, optionTwo }) =>
    async ({ outputPath, metaData, options, utils }) => {
      // Your plugin implementation...
    };
```

After:

```ts
const myPlugin: Plugin<{ optionOne: string; optionTwo: string }> =
  // Factory function with optional options
  ({ optionOne, optionTwo }) => ({
    onInit: async ({ options }) => {
      // Validate/mutate option values here
    };
    beforeGeneration: async ({ outputPath, metaData, options, utils }) => {
      // Generate plugin-specific artifacts
    };
  })
```

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
