### PR TITLE
feat: return human friendly error on convertToJsonSchema failure

### DIFF
--- a/.changeset/red-rivers-wash.md
+++ b/.changeset/red-rivers-wash.md
@@ -1,0 +1,5 @@
+---
+"openapi-ts-json-schema": minor
+---
+
+Return human friendly error on convertToJsonSchema failure

--- a/src/utils/convertOpenApiToJsonSchema.ts
+++ b/src/utils/convertOpenApiToJsonSchema.ts
@@ -37,10 +37,19 @@ function convertToJsonSchema<Value extends unknown>(
     }
   }
 
-  const schema = fromSchema(value);
-  // $schema is appended by @openapi-contrib/openapi-schema-to-json-schema
-  delete schema.$schema;
-  return schema;
+  try {
+    const schema = fromSchema(value);
+    // $schema is appended by @openapi-contrib/openapi-schema-to-json-schema
+    delete schema.$schema;
+    return schema;
+  } catch (error) {
+    /* v8 ignore next 1 */
+    const errorMessage = error instanceof Error ? error.message : '';
+    throw new Error(
+      `[openapi-ts-json-schema] OpenApi to JSON schema conversion failed: "${errorMessage}}"`,
+      { cause: value },
+    );
+  }
 }
 
 /**

--- a/test/unit/convertOpenApiToJsonSchema.test.ts
+++ b/test/unit/convertOpenApiToJsonSchema.test.ts
@@ -118,5 +118,20 @@ describe('convertOpenApiToJsonSchema', () => {
         expect(actual).toEqual(expected);
       });
     });
+
+    describe('on error', () => {
+      it('returns human friendly error', () => {
+        expect(() => {
+          convertOpenApiToJsonSchema({
+            type: 'object',
+            properties: {
+              bar: { type: 'invalid-type' },
+            },
+          });
+        }).toThrowError(
+          '[openapi-ts-json-schema] OpenApi to JSON schema conversion failed:',
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behaviour?

Unhandled [openapi-schema-to-json-schema](https://github.com/openapi-contrib/openapi-schema-to-json-schema) failures

## What is the new behaviour?

Rethrow human friendly error message

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
