### PR TITLE
refactor: skip validation on openAPI to JSON schema conversion

### DIFF
--- a/.changeset/stupid-scissors-help.md
+++ b/.changeset/stupid-scissors-help.md
@@ -1,0 +1,5 @@
+---
+"openapi-ts-json-schema": patch
+---
+
+Skip "type" prop valdation on OpenAPI --> JSON schema conversion

--- a/src/utils/convertOpenApiToJsonSchema.ts
+++ b/src/utils/convertOpenApiToJsonSchema.ts
@@ -18,27 +18,8 @@ function convertToJsonSchema<Value extends unknown>(
     return value;
   }
 
-  if ('type' in value) {
-    /**
-     * Skip entities with "type" props defined and not a string
-     * (They should have already been converted, anyway)
-     * https://github.com/toomuchdesign/openapi-ts-json-schema/issues/211
-     */
-    if (typeof value.type !== 'string') {
-      return value;
-    }
-
-    /**
-     * Skip security scheme object definitions
-     * https://swagger.io/specification/#security-scheme-object
-     */
-    if (SECURITY_SCHEME_OBJECT_TYPES.includes(value.type)) {
-      return value;
-    }
-  }
-
   try {
-    const schema = fromSchema(value);
+    const schema = fromSchema(value, { strictMode: false });
     // $schema is appended by @openapi-contrib/openapi-schema-to-json-schema
     delete schema.$schema;
     return schema;
@@ -46,7 +27,7 @@ function convertToJsonSchema<Value extends unknown>(
     /* v8 ignore next 1 */
     const errorMessage = error instanceof Error ? error.message : '';
     throw new Error(
-      `[openapi-ts-json-schema] OpenApi to JSON schema conversion failed: "${errorMessage}}"`,
+      `[openapi-ts-json-schema] OpenApi to JSON schema conversion failed: "${errorMessage}"`,
       { cause: value },
     );
   }

--- a/src/utils/makeTsJsonSchema/replacePlaceholdersWithImportedSchemas.ts
+++ b/src/utils/makeTsJsonSchema/replacePlaceholdersWithImportedSchemas.ts
@@ -21,13 +21,13 @@ export function replacePlaceholdersWithImportedSchemas({
   let output = schemaAsText.replaceAll(PLACEHOLDER_REGEX, (_match, id) => {
     const importedSchema = schemaMetaDataMap.get(id);
 
-    /* c8 ignore start */
+    /* v8 ignore start */
     if (!importedSchema) {
       throw new Error(
         '[openapi-ts-json-schema] No matching schema found in "schemaMetaDataMap"',
       );
     }
-    /* c8 ignore stop */
+    /* v8 ignore stop */
 
     // Evaluate imported schema relative path from current schema file
     const importedSchemaRelativePath = makeRelativeModulePath({

--- a/test/unit/convertOpenApiToJsonSchema.test.ts
+++ b/test/unit/convertOpenApiToJsonSchema.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { convertOpenApiToJsonSchema } from '../../src/utils';
+import * as openapiSchemaToJsonSchema from '@openapi-contrib/openapi-schema-to-json-schema';
 
 const openApiDefinition = {
   type: 'string',
@@ -121,6 +122,11 @@ describe('convertOpenApiToJsonSchema', () => {
 
     describe('on error', () => {
       it('returns human friendly error', () => {
+        const spy = vi.spyOn(openapiSchemaToJsonSchema, 'fromSchema');
+        spy.mockImplementationOnce(() => {
+          throw new Error('Error reason');
+        });
+
         expect(() => {
           convertOpenApiToJsonSchema({
             type: 'object',
@@ -129,7 +135,7 @@ describe('convertOpenApiToJsonSchema', () => {
             },
           });
         }).toThrowError(
-          '[openapi-ts-json-schema] OpenApi to JSON schema conversion failed:',
+          '[openapi-ts-json-schema] OpenApi to JSON schema conversion failed: "Error reason"',
         );
       });
     });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor

## What is the current behaviour?

`@openapi-contrib/openapi-schema-to-json-schema` be default tries to validate input `type` props causing unexpected failure during recursive the OpenAPI -> JSON schema conversion

## What is the new behaviour?

`fromSchema` invoked with `strictiMode` disabled option.
 
## Does this PR introduce a breaking change?

Not exactly. Some failing scenarios could be able to succeed

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
