### PR TITLE
feat: convert components.parameters definitions to JSON schema

### DIFF
--- a/.changeset/metal-camels-fetch.md
+++ b/.changeset/metal-camels-fetch.md
@@ -1,0 +1,5 @@
+---
+"openapi-ts-json-schema": minor
+---
+
+Convert components.parameters definitions to JSON schema

--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ Read [plugins documentation 📖](./docs/plugins.md).
 - Improve external `#ref`s handling (currently being inlined and duplicated)
 - Find a way to merge multiple different OpenApi definitions consistently
 - Consider implementing an option to inline circular $refs with a configurable nesting level
-- Convert shared parameters in `components.parameters`
 - Handle `$ref` parameters according to `refHandler` options
 
 [ci-badge]: https://github.com/toomuchdesign/openapi-ts-json-schema/actions/workflows/ci.yml/badge.svg

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Given an OpenAPI definition file, `openapi-ts-json-schema` will:
 
 TypeScript JSON schemas are 100% valid JSON schemas.
 
+`openapi-ts-json-schema` is currently in v0, which means it's still in its testing phase. I'm actively collecting feedback from users to improve its functionality and usability. **Please don't hesitate to open an issue if you encounter any problems or issues while using it.**
+
 ## Installation
 
 ```
@@ -159,6 +161,8 @@ Read [plugins documentation 📖](./docs/plugins.md).
 - Improve external `#ref`s handling (currently being inlined and duplicated)
 - Find a way to merge multiple different OpenApi definitions consistently
 - Consider implementing an option to inline circular $refs with a configurable nesting level
+- Convert shared parameters in `components.parameters`
+- Handle `$ref` parameters according to `refHandler` options
 
 [ci-badge]: https://github.com/toomuchdesign/openapi-ts-json-schema/actions/workflows/ci.yml/badge.svg
 [ci]: https://github.com/toomuchdesign/openapi-ts-json-schema/actions/workflows/ci.yml

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -67,6 +67,27 @@ Schemas without $id are the ones used to resolve refs.
 
 `keep` option was implemented as last, and it currently follows the same flow as the `import` except for point 5, where schemas with **string placeholders** are replaced with the an actual `$ref` value.
 
+## Shared OpenAPI parameters
+
+OpenAPI parameters can be `$ref`ed in 2 ways:
+
+```yaml
+parameters:
+  # Locally defined parameters with $ref schema
+  - schema:
+      $ref: '#/components/schemas/Answer'
+    in: header
+    name: header-param-2
+    required: true
+    description: header-param-2 description
+  # Full $ref parameters
+  - $ref: '#/components/parameters/componentParameter'
+```
+
+**Locally defined parameter with $ref schema** should be fully supported.
+
+**Full $ref parameters** are currently always inlined since parameters conversion is currently delegated to `openapi-jsonschema-parameters`.
+
 ## OpenAPI $ref vs JSON schema $id
 
 - [OpenAPI `$ref`s documentation](https://swagger.io/docs/specification/using-ref/)

--- a/src/utils/addSchemaToMetaData.ts
+++ b/src/utils/addSchemaToMetaData.ts
@@ -1,7 +1,12 @@
 import path from 'node:path';
 // @ts-expect-error no type defs for namify
 import namify from 'namify';
-import { filenamify, parseId } from '.';
+import {
+  filenamify,
+  parseId,
+  isOpenApiParameter,
+  convertOpenApiParameterToJsonSchema,
+} from '.';
 import type { SchemaMetaDataMap, SchemaMetaData, JSONSchema } from '../types';
 
 /*
@@ -29,6 +34,11 @@ export function addSchemaToMetaData({
     const absoluteDirName = path.join(outputPath, schemaRelativeDirName);
     const schemaFileName = filenamify(schemaName);
     const absoluteImportPath = path.join(absoluteDirName, schemaFileName);
+
+    // Convert components.parameters after convertOpenApiPathsParameters is called
+    if (isOpenApiParameter(schema)) {
+      schema = convertOpenApiParameterToJsonSchema(schema);
+    }
 
     const metaInfo: SchemaMetaData = {
       id,

--- a/src/utils/convertOpenApiParameterToJsonSchema.ts
+++ b/src/utils/convertOpenApiParameterToJsonSchema.ts
@@ -1,0 +1,9 @@
+import { fromParameter } from '@openapi-contrib/openapi-schema-to-json-schema';
+import type { JSONSchema } from '../types';
+
+export function convertOpenApiParameterToJsonSchema(parameter: JSONSchema) {
+  const schema = fromParameter(parameter, { strictMode: false });
+  // $schema is appended by @openapi-contrib/openapi-schema-to-json-schema
+  delete schema.$schema;
+  return schema;
+}

--- a/src/utils/convertOpenApiPathsParameters.ts
+++ b/src/utils/convertOpenApiPathsParameters.ts
@@ -27,7 +27,8 @@ function convertParametersToJsonSchema(
  * - paths[path].parameters
  * - paths[path][operation].parameters
  *
- * Shared $ref parameters are currently always inlined
+ * Parameters schema $refs are fully supported
+ * $ref parameters are currently always inlined
  *
  * OpenAPI parameters docs:
  * https://swagger.io/docs/specification/describing-parameters/

--- a/src/utils/convertOpenApiPathsParameters.ts
+++ b/src/utils/convertOpenApiPathsParameters.ts
@@ -23,14 +23,18 @@ function convertParametersToJsonSchema(
 }
 
 /**
- * Paths parameters field can only be found in:
+ *
+ * We currently only convert parameters found in:
  * - paths[path].parameters
  * - paths[path][operation].parameters
  *
+ * Shared components in "components.parameters" are currently not even converted
+ * Shared $ref parameters are currently always inlined
+ *
+ * OpenAPI parameters docs:
  * https://swagger.io/docs/specification/describing-parameters/
  *
- * @NOTE The schema must be dereferenced since openapi-jsonschema-parameters
- * doesn't handle $refs
+ * @NOTE The schema must be dereferenced since openapi-jsonschema-parameters doesn't handle $refs
  */
 export function convertOpenApiPathsParameters(schema: JSONSchema): JSONSchema {
   if ('paths' in schema) {

--- a/src/utils/convertOpenApiPathsParameters.ts
+++ b/src/utils/convertOpenApiPathsParameters.ts
@@ -23,12 +23,10 @@ function convertParametersToJsonSchema(
 }
 
 /**
- *
- * We currently only convert parameters found in:
+ * Convert parameters found in:
  * - paths[path].parameters
  * - paths[path][operation].parameters
  *
- * Shared components in "components.parameters" are currently not even converted
  * Shared $ref parameters are currently always inlined
  *
  * OpenAPI parameters docs:

--- a/src/utils/convertOpenApiToJsonSchema.ts
+++ b/src/utils/convertOpenApiToJsonSchema.ts
@@ -10,6 +10,11 @@ function convertToJsonSchema<Value extends unknown>(
     return value;
   }
 
+  // Skip openAPI parameters
+  if ('in' in value) {
+    return value;
+  }
+
   try {
     const schema = fromSchema(value, { strictMode: false });
     // $schema is appended by @openapi-contrib/openapi-schema-to-json-schema

--- a/src/utils/convertOpenApiToJsonSchema.ts
+++ b/src/utils/convertOpenApiToJsonSchema.ts
@@ -3,14 +3,6 @@ import { fromSchema } from '@openapi-contrib/openapi-schema-to-json-schema';
 import { isObject } from './';
 import type { OpenApiSchema, JSONSchema } from '../types';
 
-const SECURITY_SCHEME_OBJECT_TYPES = [
-  'apiKey',
-  'http',
-  'mutualTLS',
-  'oauth2',
-  'openIdConnect',
-];
-
 function convertToJsonSchema<Value extends unknown>(
   value: Value,
 ): JSONSchema | Value {

--- a/src/utils/convertOpenApiToJsonSchema.ts
+++ b/src/utils/convertOpenApiToJsonSchema.ts
@@ -1,6 +1,6 @@
 import mapObject from 'map-obj';
 import { fromSchema } from '@openapi-contrib/openapi-schema-to-json-schema';
-import { isObject } from './';
+import { isObject, isOpenApiParameter } from './';
 import type { OpenApiSchema, JSONSchema } from '../types';
 
 function convertToJsonSchema<Value extends unknown>(
@@ -16,7 +16,7 @@ function convertToJsonSchema<Value extends unknown>(
    *
    * Conversion is carried out later with "convertOpenApiPathsParameters"
    */
-  if ('in' in value) {
+  if (isOpenApiParameter(value)) {
     return value;
   }
 

--- a/src/utils/convertOpenApiToJsonSchema.ts
+++ b/src/utils/convertOpenApiToJsonSchema.ts
@@ -10,7 +10,12 @@ function convertToJsonSchema<Value extends unknown>(
     return value;
   }
 
-  // Skip openAPI parameters
+  /**
+   * Skip openAPI parameters since conversion causes data loss (they are not valid JSON schema)
+   * which makes impossible to aggregate them into JSON schema.
+   *
+   * Conversion is carried out later with "convertOpenApiPathsParameters"
+   */
   if ('in' in value) {
     return value;
   }
@@ -45,6 +50,13 @@ export function convertOpenApiToJsonSchema(
   return mapObject(
     schema,
     (key, value) => {
+      /**
+       * @NOTE map-obj only processes object values separately
+       */
+      if (Array.isArray(value)) {
+        return [key, value.map((entry) => convertToJsonSchema(entry))];
+      }
+
       // @NOTE map-obj transforms only arrays entries which are objects
       return [key, convertToJsonSchema(value)];
     },

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,7 @@ export { patchJsonSchema } from './makeTsJsonSchema/patchJsonSchema';
 export { makeTsJsonSchema } from './makeTsJsonSchema';
 export { convertOpenApiPathsParameters } from './convertOpenApiPathsParameters';
 export { convertOpenApiToJsonSchema } from './convertOpenApiToJsonSchema';
+export { convertOpenApiParameterToJsonSchema } from './convertOpenApiParameterToJsonSchema';
 export { makeTsJsonSchemaFiles } from './makeTsJsonSchemaFiles';
 export { parseId } from './parseId';
 export { refToId } from './refToId';
@@ -16,6 +17,7 @@ export { replacePlaceholdersWithImportedSchemas } from './makeTsJsonSchema/repla
 export { addSchemaToMetaData } from './addSchemaToMetaData';
 export { isObject } from './isObject';
 export { filenamify } from './filenamify';
+export { isOpenApiParameter } from './isOpenApiParameter';
 
 export { clearFolder } from './clearFolder';
 export { makeRelativeModulePath } from './makeRelativeModulePath';

--- a/src/utils/isOpenApiParameter.ts
+++ b/src/utils/isOpenApiParameter.ts
@@ -1,0 +1,27 @@
+import { isObject } from '.';
+('./');
+
+const PARAMETERS_IN_VALUES = [
+  'query',
+  'header',
+  'path',
+  'cookie',
+  'formData',
+  'body',
+];
+
+/**
+ * Detect OpenAPI parameters
+ * https://swagger.io/docs/specification/describing-parameters/
+ */
+export function isOpenApiParameter(schema: unknown): boolean {
+  if (
+    isObject(schema) &&
+    typeof schema.in === 'string' &&
+    PARAMETERS_IN_VALUES.includes(schema.in)
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/utils/makeTsJsonSchema/replaceInlinedRefsWithStringPlaceholder.ts
+++ b/src/utils/makeTsJsonSchema/replaceInlinedRefsWithStringPlaceholder.ts
@@ -33,7 +33,10 @@ export function replaceInlinedRefsWithStringPlaceholder(
   return mapObject(
     schema,
     (key, value) => {
-      // @NOTE map-obj transforms only arrays entries which are objects
+      /**
+       * @NOTE map-obj transforms only arrays entries which are objects
+       * @NOTE map-obj only processes object values separately
+       */
       if (Array.isArray(value)) {
         return [
           key,

--- a/test/fixtures/paths-parameters/specs.yaml
+++ b/test/fixtures/paths-parameters/specs.yaml
@@ -10,6 +10,14 @@ components:
       enum:
         - yes
         - no
+  parameters:
+    componentParameter:
+      in: query
+      name: component-parameter-name
+      required: true
+      schema:
+        nullable: true
+        type: integer
 
 paths:
   /v1/path-1:
@@ -68,6 +76,8 @@ paths:
           name: query-param-1
           required: true
           description: Query param description
+        # Shared components parameter
+        - $ref: '#/components/parameters/componentParameter'
       responses:
         '200':
           content:

--- a/test/paths-parameters.test.ts
+++ b/test/paths-parameters.test.ts
@@ -73,6 +73,7 @@ describe('OpenAPI paths parameters', () => {
               'query-param-1': {
                 type: 'string',
               },
+              // Components parameters are currently always inlined
               'component-parameter-name': {
                 type: ['integer', 'null'],
               },

--- a/test/paths-parameters.test.ts
+++ b/test/paths-parameters.test.ts
@@ -71,11 +71,13 @@ describe('OpenAPI paths parameters', () => {
               'query-param-1': {
                 type: 'string',
               },
+              'component-parameter-name': {
+                type: ['integer', 'null'],
+              },
             },
-            required: ['query-param-1'],
+            required: ['query-param-1', 'component-parameter-name'],
           },
         },
-
         responses: {
           '200': {
             content: { 'application/json': { schema: { type: 'string' } } },

--- a/test/paths-parameters.test.ts
+++ b/test/paths-parameters.test.ts
@@ -2,7 +2,6 @@ import path from 'path';
 import { describe, it, expect } from 'vitest';
 import { fixtures, makeTestOutputPath } from './test-utils';
 import { openapiToTsJsonSchema } from '../src';
-import { fromParameter } from '@openapi-contrib/openapi-schema-to-json-schema';
 
 describe('OpenAPI paths parameters', () => {
   it('Transforms parameters array into valid JSON schema', async () => {

--- a/test/paths-parameters.test.ts
+++ b/test/paths-parameters.test.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { describe, it, expect } from 'vitest';
 import { fixtures, makeTestOutputPath } from './test-utils';
 import { openapiToTsJsonSchema } from '../src';
+import { fromParameter } from '@openapi-contrib/openapi-schema-to-json-schema';
 
 describe('OpenAPI paths parameters', () => {
   it('Transforms parameters array into valid JSON schema', async () => {
@@ -9,6 +10,7 @@ describe('OpenAPI paths parameters', () => {
       openApiSchema: path.resolve(fixtures, 'paths-parameters/specs.yaml'),
       outputPath: makeTestOutputPath('paths-parameters'),
       definitionPathsToGenerateFrom: ['paths'],
+      refHandling: 'import',
       silent: true,
     });
 
@@ -85,5 +87,14 @@ describe('OpenAPI paths parameters', () => {
         },
       },
     });
+
+    // @TODO convert shared parameter schemas
+    // const sharedParametersSchema = await import(
+    //   path.resolve(outputPath, 'components/parameters/componentParameter')
+    // );
+
+    // expect(sharedParametersSchema.default).toEqual({
+    //   type: ['integer', 'null'],
+    // });
   });
 });

--- a/test/paths-parameters.test.ts
+++ b/test/paths-parameters.test.ts
@@ -4,97 +4,118 @@ import { fixtures, makeTestOutputPath } from './test-utils';
 import { openapiToTsJsonSchema } from '../src';
 
 describe('OpenAPI paths parameters', () => {
-  it('Transforms parameters array into valid JSON schema', async () => {
-    const { outputPath } = await openapiToTsJsonSchema({
-      openApiSchema: path.resolve(fixtures, 'paths-parameters/specs.yaml'),
-      outputPath: makeTestOutputPath('paths-parameters'),
-      definitionPathsToGenerateFrom: ['paths'],
-      refHandling: 'import',
-      silent: true,
-    });
+  describe.each([
+    { refHandling: 'import' } as const,
+    { refHandling: 'inline' } as const,
+    { refHandling: 'keep' } as const,
+  ])('refHandling: "$refHandling"', ({ refHandling }) => {
+    it('Transforms parameters array into valid JSON schema', async () => {
+      const { outputPath } = await openapiToTsJsonSchema({
+        openApiSchema: path.resolve(fixtures, 'paths-parameters/specs.yaml'),
+        outputPath: makeTestOutputPath(`paths-parameters--${refHandling}`),
+        definitionPathsToGenerateFrom: ['paths'],
+        refHandling,
+        silent: true,
+      });
 
-    const pathSchema = await import(
-      path.resolve(outputPath, 'paths/v1_path-1')
-    );
+      const pathSchema = await import(
+        path.resolve(outputPath, 'paths/v1_path-1')
+      );
 
-    expect(pathSchema.default).toEqual({
-      $id: '/paths/v1_path-1',
-      parameters: {
-        headers: {
-          type: 'object',
-          required: ['path-header-param'],
-          properties: {
-            'path-header-param': {
-              type: 'string',
-            },
-            'path-header-param-overridden-at-operation-level': {
-              type: 'string',
-            },
-          },
-        },
-      },
-      get: {
+      expect(pathSchema.default).toEqual({
+        $id: '/paths/v1_path-1',
         parameters: {
           headers: {
             type: 'object',
+            required: ['path-header-param'],
             properties: {
-              'header-param-1': {
-                type: 'string',
-              },
-              'header-param-2': {
-                type: 'string',
-                enum: ['yes', 'no'],
-              },
-              // Merges path level parameters
               'path-header-param': {
                 type: 'string',
               },
-              // Overrides path level parameters
               'path-header-param-overridden-at-operation-level': {
-                type: 'number',
-              },
-            },
-            required: ['path-header-param', 'header-param-1', 'header-param-2'],
-          },
-          body: { type: 'string', enum: ['foo', 'bar'] },
-          path: {
-            type: 'object',
-            properties: {
-              'path-param-1': {
                 type: 'string',
               },
             },
-            required: ['path-param-1'],
           },
-          query: {
-            type: 'object',
-            properties: {
-              'query-param-1': {
-                type: 'string',
+        },
+        get: {
+          parameters: {
+            headers: {
+              type: 'object',
+              properties: {
+                'header-param-1': {
+                  type: 'string',
+                },
+                // Parameters schema $refs are fully supported
+                'header-param-2':
+                  refHandling === 'keep'
+                    ? {
+                        $ref: '/components/schemas/Answer',
+                      }
+                    : {
+                        type: 'string',
+                        enum: ['yes', 'no'],
+                      },
+                // Merges path level parameters
+                'path-header-param': {
+                  type: 'string',
+                },
+                // Overrides path level parameters
+                'path-header-param-overridden-at-operation-level': {
+                  type: 'number',
+                },
               },
-              // Components parameters are currently always inlined
-              'component-parameter-name': {
-                type: ['integer', 'null'],
-              },
+              required: [
+                'path-header-param',
+                'header-param-1',
+                'header-param-2',
+              ],
             },
-            required: ['query-param-1', 'component-parameter-name'],
+            body: { type: 'string', enum: ['foo', 'bar'] },
+            path: {
+              type: 'object',
+              properties: {
+                'path-param-1': {
+                  type: 'string',
+                },
+              },
+              required: ['path-param-1'],
+            },
+            query: {
+              type: 'object',
+              properties: {
+                'query-param-1': {
+                  type: 'string',
+                },
+                // $ref parameters are currently always inlined
+                'component-parameter-name': {
+                  type: ['integer', 'null'],
+                },
+              },
+              required: ['query-param-1', 'component-parameter-name'],
+            },
+          },
+          responses: {
+            '200': {
+              content: { 'application/json': { schema: { type: 'string' } } },
+            },
           },
         },
-        responses: {
-          '200': {
-            content: { 'application/json': { schema: { type: 'string' } } },
-          },
-        },
-      },
+      });
+
+      /**
+       * Generates components.parameters schemas as JSON schema
+       */
+      if (refHandling === 'import') {
+        const sharedParametersSchema = await import(
+          path.resolve(outputPath, 'components/parameters/componentParameter')
+        );
+
+        expect(sharedParametersSchema.default).toEqual({
+          $id: '/components/parameters/componentParameter',
+          type: ['integer', 'null'],
+        });
+      }
     });
-
-    // @TODO convert shared parameter schemas
-    // const sharedParametersSchema = await import(
-    //   path.resolve(outputPath, 'components/parameters/componentParameter')
-    // );
-
-    // expect(sharedParametersSchema.default).toEqual({
-    //   type: ['integer', 'null'],
-    // });
   });
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behaviour?

`components.parameters` definitions not converted to JSON schema and generated as OpenAPI parameter definitions

## What is the new behaviour?

`components.parameters` definition generated as JSON schemas.

## Does this PR introduce a breaking change?

Yes, previously generated `components.parameters` definitions are now generated as JSON schema.

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
