### PR TITLE
refactor: preserve leading "/" on schema id generation

### DIFF
--- a/.changeset/new-worms-clap.md
+++ b/.changeset/new-worms-clap.md
@@ -1,0 +1,5 @@
+---
+"openapi-ts-json-schema": patch
+---
+
+Fix "/" api paths being stored out of paths folder

--- a/.changeset/quiet-dolphins-pull.md
+++ b/.changeset/quiet-dolphins-pull.md
@@ -1,0 +1,5 @@
+---
+"openapi-ts-json-schema": minor
+---
+
+Leading "/" in schema filenames not removed anymore. Path schemas filanames handled as: "/my/path" --> "\_my_path".

--- a/examples/fastify-integration-plugin/definitions/petstore/schemas-autogenerated/paths/_pets.ts
+++ b/examples/fastify-integration-plugin/definitions/petstore/schemas-autogenerated/paths/_pets.ts
@@ -1,5 +1,5 @@
 const schema = {
-  $id: "/paths/pets",
+  $id: "/paths/_pets",
   get: {
     summary: "List all pets",
     operationId: "listPets",

--- a/examples/fastify-integration-plugin/definitions/petstore/schemas-autogenerated/paths/_pets_{petId}.ts
+++ b/examples/fastify-integration-plugin/definitions/petstore/schemas-autogenerated/paths/_pets_{petId}.ts
@@ -1,5 +1,5 @@
 const schema = {
-  $id: "/paths/pets_{petId}",
+  $id: "/paths/_pets_{petId}",
   get: {
     summary: "Info for a specific pet",
     operationId: "showPetById",

--- a/src/utils/filenamify.ts
+++ b/src/utils/filenamify.ts
@@ -5,12 +5,8 @@ import _filenamify from 'filenamify';
  * and any other file path unsafe character with "!"
  */
 
-const TRAILING_SLASH_REGEX = /^\//;
 export function filenamify(name: string): string {
-  return _filenamify(
-    name.replace(TRAILING_SLASH_REGEX, '').replaceAll('/', '_'),
-    {
-      replacement: '!',
-    },
-  );
+  return _filenamify(name.replaceAll('/', '_'), {
+    replacement: '!',
+  });
 }

--- a/test/dereferencing.test.ts
+++ b/test/dereferencing.test.ts
@@ -36,7 +36,7 @@ describe('Dereferencing', () => {
     });
 
     const pathsSchema = await import(
-      path.resolve(outputPath, 'paths/v1_path-1')
+      path.resolve(outputPath, 'paths/_v1_path-1')
     );
 
     expect(

--- a/test/fixtures/paths/specs.yaml
+++ b/test/fixtures/paths/specs.yaml
@@ -5,6 +5,16 @@ info:
   version: 1.0.0
 
 paths:
+  /:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                nullable: true
+                type: string
+
   /users/{id}:
     get:
       tags:

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -21,7 +21,7 @@ describe('openapiToTsJsonSchema', () => {
     );
 
     // definition paths get escaped
-    const path1 = await import(path.resolve(outputPath, 'paths/v1_path-1'));
+    const path1 = await import(path.resolve(outputPath, 'paths/_v1_path-1'));
 
     expect(januarySchema.default).toEqual({
       $id: '/components/schemas/January',
@@ -44,7 +44,7 @@ describe('openapiToTsJsonSchema', () => {
     });
 
     expect(path1.default).toEqual({
-      $id: '/paths/v1_path-1',
+      $id: '/paths/_v1_path-1',
       get: {
         responses: {
           '200': {

--- a/test/openAPI-v2.test.ts
+++ b/test/openAPI-v2.test.ts
@@ -23,9 +23,11 @@ describe('OpenAPI v2', async () => {
       },
     });
 
-    const petsPathSchema = await import(path.resolve(outputPath, 'paths/pets'));
+    const petsPathSchema = await import(
+      path.resolve(outputPath, 'paths/_pets')
+    );
     expect(petsPathSchema.default).toEqual({
-      $id: '/paths/pets',
+      $id: '/paths/_pets',
       get: {
         description:
           'Returns all pets from the system that the user has access to',

--- a/test/paths-parameters.test.ts
+++ b/test/paths-parameters.test.ts
@@ -19,11 +19,11 @@ describe('OpenAPI paths parameters', () => {
       });
 
       const pathSchema = await import(
-        path.resolve(outputPath, 'paths/v1_path-1')
+        path.resolve(outputPath, 'paths/_v1_path-1')
       );
 
       expect(pathSchema.default).toEqual({
-        $id: '/paths/v1_path-1',
+        $id: '/paths/_v1_path-1',
         parameters: {
           headers: {
             type: 'object',

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -5,15 +5,33 @@ import { openapiToTsJsonSchema } from '../src';
 
 describe('OpenAPI paths', () => {
   it('Generates expected paths schemas', async () => {
-    const { outputPath } = await openapiToTsJsonSchema({
+    const { outputPath, metaData } = await openapiToTsJsonSchema({
       openApiSchema: path.resolve(fixtures, 'paths/specs.yaml'),
       outputPath: makeTestOutputPath('paths'),
       definitionPathsToGenerateFrom: ['paths'],
       silent: true,
     });
 
-    const pathSchema = await import(
-      path.resolve(outputPath, 'paths/users_{id}')
+    const rootPathSchema = await import(path.resolve(outputPath, 'paths/_'));
+    expect(rootPathSchema.default).toEqual({
+      $id: '/paths/_',
+      get: {
+        responses: {
+          '200': {
+            content: {
+              'application/json': {
+                schema: {
+                  type: ['string', 'null'],
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const usersPathSchema = await import(
+      path.resolve(outputPath, 'paths/_users_{id}')
     );
 
     const componentsSchemasUser = {
@@ -29,8 +47,8 @@ describe('OpenAPI paths', () => {
       required: ['id', 'name'],
     };
 
-    expect(pathSchema.default).toEqual({
-      $id: '/paths/users_{id}',
+    expect(usersPathSchema.default).toEqual({
+      $id: '/paths/_users_{id}',
       get: {
         tags: ['Users'],
         summary: 'Gets a user by ID.',

--- a/test/refHandling-import.test.ts
+++ b/test/refHandling-import.test.ts
@@ -29,11 +29,11 @@ describe('refHandling option === "import"', () => {
         refHandling: 'import',
       });
 
-      const path1 = await import(path.resolve(outputPath, 'paths/v1_path-1'));
+      const path1 = await import(path.resolve(outputPath, 'paths/_v1_path-1'));
 
       // Expectations against parsed root schema
       expect(path1.default).toEqual({
-        $id: '/paths/v1_path-1',
+        $id: '/paths/_v1_path-1',
         get: {
           responses: {
             '200': {
@@ -80,7 +80,7 @@ describe('refHandling option === "import"', () => {
 
       // Expectations against actual root schema file (make sure it actually imports refs :))
       const actualPath1File = await fs.readFile(
-        path.resolve(outputPath, 'paths/v1_path-1.ts'),
+        path.resolve(outputPath, 'paths/_v1_path-1.ts'),
         {
           encoding: 'utf8',
         },
@@ -91,7 +91,7 @@ describe('refHandling option === "import"', () => {
         import { without$id as componentsSchemasJanuary } from "./../components/schemas/January";
 
         const schema = {
-          $id: "/paths/v1_path-1",
+          $id: "/paths/_v1_path-1",
           get: {
             responses: {
               "200": {

--- a/test/refHandling-keep.test.ts
+++ b/test/refHandling-keep.test.ts
@@ -15,11 +15,11 @@ describe('refHandling option === "keep"', () => {
       refHandling: 'keep',
     });
 
-    const path1 = await import(path.resolve(outputPath, 'paths/v1_path-1'));
+    const path1 = await import(path.resolve(outputPath, 'paths/_v1_path-1'));
 
     // Expectations against parsed root schema
     expect(path1.default).toEqual({
-      $id: '/paths/v1_path-1',
+      $id: '/paths/_v1_path-1',
       get: {
         responses: {
           '200': {
@@ -46,7 +46,7 @@ describe('refHandling option === "keep"', () => {
 
     // Expectations against actual root schema file
     const actualPath1File = await fs.readFile(
-      path.resolve(outputPath, 'paths/v1_path-1.ts'),
+      path.resolve(outputPath, 'paths/_v1_path-1.ts'),
       {
         encoding: 'utf8',
       },
@@ -55,7 +55,7 @@ describe('refHandling option === "keep"', () => {
     // Ensure "as const" is present
     const expectedPath1File = await formatTypeScript(`
       const schema = {
-        $id: '/paths/v1_path-1',
+        $id: '/paths/_v1_path-1',
         get: {
           responses: {
             "200": {

--- a/test/schemaPatcher.test.ts
+++ b/test/schemaPatcher.test.ts
@@ -33,7 +33,7 @@ describe('"schemaPatcher" option', () => {
 
     // Testing deep nested props being patched, too
     const pathSchema = await import(
-      path.resolve(outputPath, 'paths/v1_path-1')
+      path.resolve(outputPath, 'paths/_v1_path-1')
     );
 
     expect(

--- a/test/unit/makeId.test.ts
+++ b/test/unit/makeId.test.ts
@@ -18,6 +18,27 @@ describe('makeId', () => {
       schemaName: 'Foo',
       expected: '/components/schemas/Foo',
     },
+    {
+      schemaRelativeDirName: 'components.schemas',
+      schemaName: 'Foo/bar',
+      expected: '/components/schemas/Foo_bar',
+    },
+    {
+      schemaRelativeDirName: 'components/schemas',
+      schemaName: 'Foo/bar',
+      expected: '/components/schemas/Foo_bar',
+    },
+    {
+      schemaRelativeDirName: 'paths',
+      schemaName: '/users',
+      expected: '/paths/_users',
+    },
+    {
+      schemaRelativeDirName: 'paths',
+      schemaName: '/',
+      expected: '/paths/_',
+    },
+
     // Windows path separators
     {
       schemaRelativeDirName: 'components\\schemas',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix + refactor

## What is the current behaviour?

Root path schemas "/" being generated out of `paths` folder.

## What is the new behaviour?

Schemas id and subsequent schema paths preserve leading `/`.

## Does this PR introduce a breaking change?

Yes, path schemas (and ids) will be all prefixed with a `/`.

- Previous schema: `paths/my_path.ts`
- New schema: `paths/_my_path.ts`

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [x] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
