### PR TITLE
refactor: minor improvements

### DIFF
--- a/.changeset/extract-constants.md
+++ b/.changeset/extract-constants.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-json-schema': patch
+---
+
+Centralise internal sentinel strings and symbols (`SCHEMA_ID_MARKER_START`, `SCHEMA_ID_MARKER_END`, `SCHEMA_ID_SYMBOL`, `COMMENT_JSON_BEFORE_SYMBOL`, `OPEN_API_COMPONENTS_SCHEMAS_PATH`) in a new `src/constants.ts` module.

--- a/.changeset/fix-options-mutation.md
+++ b/.changeset/fix-options-mutation.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-json-schema': patch
+---
+
+Fix plugin system options mutation: `plugins` array is now shallow-copied when building internal options, preventing `onInit` hooks from mutating the caller's original array.

--- a/.changeset/improve-error-messages.md
+++ b/.changeset/improve-error-messages.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-json-schema': patch
+---
+
+Improve error messages: all thrown errors now include the offending schema id or path and a hint toward the fix.

--- a/.changeset/plugin-error-handling.md
+++ b/.changeset/plugin-error-handling.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-json-schema': minor
+---
+
+Plugin hook invocations are now wrapped in try/catch; errors re-thrown with the plugin name (or index) and hook name for easier debugging. Add optional `name` property to the `Plugin` return type.

--- a/docs/findings-and-roadmap.md
+++ b/docs/findings-and-roadmap.md
@@ -31,7 +31,7 @@
 
 - [ ] **Fix the brute-force OpenAPI → JSON Schema conversion** — `convertOpenApiDocumentDefinitionsToJsonSchema.ts` recursively visits every node in the entire document with `mapObject({ deep: true })`. The code itself has a comment acknowledging this is wrong. OpenAPI defines specific fields that are schema objects; only those should be converted. Implement targeted conversion that follows the OpenAPI spec's definition of which fields are schema objects. Additionally, for OpenAPI v3.1.0 (which is already valid JSON Schema), skip conversion entirely — the version detection and conditional logic is missing.
 
-- [ ] **Fix options mutation in plugin system** — `fastifyIntegrationPlugin.onInit` mutates the user-supplied `options` object in place (`options.refHandling = 'keep'`, `options.plugins.push(...)`). This creates hidden side effects and makes plugin ordering a source of bugs. Make a defensive copy of options at the start of `openapiToTsJsonSchema`, and document that plugins receive a snapshot, not a reference.
+- [x] **Fix options mutation in plugin system** — `fastifyIntegrationPlugin.onInit` mutates the user-supplied `options` object in place (`options.refHandling = 'keep'`, `options.plugins.push(...)`). This creates hidden side effects and makes plugin ordering a source of bugs. Make a defensive copy of options at the start of `openapiToTsJsonSchema`, and document that plugins receive a snapshot, not a reference.
 
 - [ ] **Harden the `namify` dependency** — Import names for generated schemas are derived via the `namify` package, which has no type definitions (suppressed with `@ts-expect-error`). There are no tests for edge cases: numeric-only names (`123`), hyphenated names (`my-schema`), or JavaScript reserved words (`class`, `return`, `type`). Add explicit tests for these cases and handle them with a deterministic fallback.
 
@@ -43,7 +43,7 @@
 
 ## Section 3 — High: developer experience
 
-- [ ] **Improve error messages throughout** — Current errors include bare strings like "No matching schema found" and "Unsupported id value" with no context (which schema? what value was received?). Every thrown error should include: the offending schema id or path, the received value where applicable, and a hint toward the fix. Create a small set of custom error classes (e.g. `SchemaNotFoundError`, `InvalidIdError`) to make errors catchable programmatically.
+- [x] **Improve error messages throughout** — Current errors include bare strings like "No matching schema found" and "Unsupported id value" with no context (which schema? what value was received?). Every thrown error should include: the offending schema id or path, the received value where applicable, and a hint toward the fix. Create a small set of custom error classes (e.g. `SchemaNotFoundError`, `InvalidIdError`) to make errors catchable programmatically.
 
 - [ ] **Add input validation for `targets`** — The `targets.collections` and `targets.single` arrays are not validated. Invalid dot-notation paths (e.g. a typo) result in silent empty output rather than a useful error. Add a validation step that checks each target path exists in the bundled document and throws with a clear message if not.
 
@@ -61,7 +61,7 @@
 
 ## Section 4 — Medium: design and maintainability
 
-- [ ] **Extract magic strings and symbols to a constants file** — The placeholder markers (`_OTJS-START_`, `_OTJS-END_`), the Symbol key (`'SCHEMA_ID_SYMBOL'`), the comment-json sentinel (`'before'`), and hardcoded paths like `/components/schemas/` are scattered across multiple files. Centralise them in a `src/constants.ts` file to make the system's moving parts discoverable and prevent typo-driven bugs.
+- [x] **Extract magic strings and symbols to a constants file** — The placeholder markers (`_OTJS-START_`, `_OTJS-END_`), the Symbol key (`'SCHEMA_ID_SYMBOL'`), the comment-json sentinel (`'before'`), and hardcoded paths like `/components/schemas/` are scattered across multiple files. Centralise them in a `src/constants.ts` file to make the system's moving parts discoverable and prevent typo-driven bugs.
 
 - [ ] **Make `clearFolder` safe** — The output directory is deleted before each generation run with no opt-out. Users who place non-generated files in the output directory (e.g. a hand-written adapter, a custom index) will lose them silently. Add a `clearOutputDir: boolean` option (default `true`) and document the destructive behaviour explicitly.
 
@@ -69,7 +69,7 @@
 
 - [ ] **Unify the `id` / `$id` / `uniqueName` fields in `SchemaMetaData`** — These three fields are all derived from the same internal path but have inconsistent values in some edge cases (circular refs, alias definitions). Document the exact contract for each field (what it contains, when it differs from the others), or consolidate if the distinction isn't meaningful for consumers.
 
-- [ ] **Add structured error handling for plugin failures** — There is no documented or implemented behaviour for when a plugin throws. Does the entire generation fail? Does it continue with remaining plugins? Define the policy (fail-fast is reasonable), wrap plugin invocations in a try/catch that re-throws with the plugin name in the error message, and document this in `docs/plugins.md`.
+- [x] **Add structured error handling for plugin failures** — There is no documented or implemented behaviour for when a plugin throws. Does the entire generation fail? Does it continue with remaining plugins? Define the policy (fail-fast is reasonable), wrap plugin invocations in a try/catch that re-throws with the plugin name in the error message, and document this in `docs/plugins.md`.
 
 - [ ] **Remove `moduleSystem` difference from import path logic** — `makeRelativeImportPath` adds a `.js` extension for ESM but not for CJS. The reason for this asymmetry is not documented and is surprising (CJS modules also use `.js`). Investigate if this is actually correct, document why in the code if it is, or fix the inconsistency.
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,9 @@
+export const SCHEMA_ID_SYMBOL = Symbol('id');
+
+export const SCHEMA_ID_MARKER_START = '_OTJS-START_';
+export const SCHEMA_ID_MARKER_END = '_OTJS-END_';
+
+/** Symbol used by comment-json to attach leading comments to a node */
+export const COMMENT_JSON_BEFORE_SYMBOL = Symbol.for('before');
+
+export const OPEN_API_COMPONENTS_SCHEMAS_PATH = '/components/schemas/';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,9 +1,13 @@
+/** Symbol key used to store a schema's internal path-based ID on schema objects */
 export const SCHEMA_ID_SYMBOL = Symbol('id');
 
+/** Delimiter marking the start of an inlined schema ID placeholder in stringified output */
 export const SCHEMA_ID_MARKER_START = '_OTJS-START_';
+/** Delimiter marking the end of an inlined schema ID placeholder in stringified output */
 export const SCHEMA_ID_MARKER_END = '_OTJS-END_';
 
 /** Symbol used by comment-json to attach leading comments to a node */
 export const COMMENT_JSON_BEFORE_SYMBOL = Symbol.for('before');
 
+/** JSON Pointer prefix for OpenAPI component schemas, used to detect and resolve $refs */
 export const OPEN_API_COMPONENTS_SCHEMAS_PATH = '/components/schemas/';

--- a/src/openapiToTsJsonSchema.ts
+++ b/src/openapiToTsJsonSchema.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { $RefParser } from '@apidevtools/json-schema-ref-parser';
 import get from 'lodash.get';
 
+import { COMMENT_JSON_BEFORE_SYMBOL } from './constants.js';
 import type {
   JSONSchema,
   OpenApiDocument,
@@ -195,7 +196,7 @@ export async function openapiToTsJsonSchema(
            * See: https://github.com/kaelzhang/node-comment-json
            */
           if (refHandling === 'inline') {
-            inlinedSchema[Symbol.for('before')] = [
+            inlinedSchema[COMMENT_JSON_BEFORE_SYMBOL] = [
               {
                 type: 'LineComment',
                 value: ` $ref: "${ref}"`,

--- a/src/openapiToTsJsonSchema.ts
+++ b/src/openapiToTsJsonSchema.ts
@@ -90,11 +90,19 @@ export async function openapiToTsJsonSchema(
   const { plugins } = optionsWithDefaults;
 
   // Execute plugins onInit method
-  for (const { onInit } of plugins) {
-    if (onInit) {
-      await onInit({
-        options: optionsWithDefaults,
-      });
+  for (const [index, plugin] of plugins.entries()) {
+    if (plugin.onInit) {
+      try {
+        await plugin.onInit({
+          options: optionsWithDefaults,
+        });
+      } catch (error) {
+        /* v8 ignore next 4 -- @preserve */
+        throw new Error(
+          `[openapi-ts-json-schema] Plugin ${plugin.name ? `"${plugin.name}"` : `at index ${index}`} failed during "onInit" hook`,
+          { cause: error },
+        );
+      }
     }
   }
 
@@ -305,17 +313,25 @@ export async function openapiToTsJsonSchema(
   };
 
   // Execute plugins onBeforeGeneration method
-  for (const { onBeforeGeneration } of plugins) {
-    if (onBeforeGeneration) {
-      await onBeforeGeneration({
-        ...returnPayload,
-        options: optionsWithDefaults,
-        utils: {
-          makeRelativeImportPath,
-          formatTypeScript,
-          saveFile,
-        },
-      });
+  for (const [index, plugin] of plugins.entries()) {
+    if (plugin.onBeforeGeneration) {
+      try {
+        await plugin.onBeforeGeneration({
+          ...returnPayload,
+          options: optionsWithDefaults,
+          utils: {
+            makeRelativeImportPath,
+            formatTypeScript,
+            saveFile,
+          },
+        });
+      } catch (error) {
+        /* v8 ignore next 4 -- @preserve */
+        throw new Error(
+          `[openapi-ts-json-schema] Plugin ${plugin.name ? `"${plugin.name}"` : `at index ${index}`} failed during "onBeforeGeneration" hook`,
+          { cause: error },
+        );
+      }
     }
   }
 
@@ -327,18 +343,26 @@ export async function openapiToTsJsonSchema(
     moduleSystem,
   });
 
-  // Execute plugins onBeforeGeneration method
-  for (const { onBeforeSaveFile } of plugins) {
-    if (onBeforeSaveFile) {
-      await onBeforeSaveFile({
-        ...returnPayload,
-        options: optionsWithDefaults,
-        utils: {
-          makeRelativeImportPath,
-          formatTypeScript,
-          saveFile,
-        },
-      });
+  // Execute plugins onBeforeSaveFile method
+  for (const [index, plugin] of plugins.entries()) {
+    if (plugin.onBeforeSaveFile) {
+      try {
+        await plugin.onBeforeSaveFile({
+          ...returnPayload,
+          options: optionsWithDefaults,
+          utils: {
+            makeRelativeImportPath,
+            formatTypeScript,
+            saveFile,
+          },
+        });
+      } catch (error) {
+        /* v8 ignore next 4 -- @preserve */
+        throw new Error(
+          `[openapi-ts-json-schema] Plugin ${plugin.name ? `"${plugin.name}"` : `at index ${index}`} failed during "onBeforeSaveFile" hook`,
+          { cause: error },
+        );
+      }
     }
   }
 

--- a/src/openapiToTsJsonSchema.ts
+++ b/src/openapiToTsJsonSchema.ts
@@ -219,7 +219,7 @@ export async function openapiToTsJsonSchema(
 
     if (!openApiDefinition) {
       throw new Error(
-        `[openapi-ts-json-schema] target not found in OAS definition: "${path}"`,
+        `[openapi-ts-json-schema] target not found in OAS definition: "${path}". Check that the path exists in your OpenAPI document.`,
       );
     }
 
@@ -248,7 +248,7 @@ export async function openapiToTsJsonSchema(
 
     if (!openApiDefinitions) {
       throw new Error(
-        `[openapi-ts-json-schema] target not found in OAS definition: "${path}"`,
+        `[openapi-ts-json-schema] target not found in OAS definition: "${path}". Check that the path exists in your OpenAPI document.`,
       );
     }
 

--- a/src/openapiToTsJsonSchema.ts
+++ b/src/openapiToTsJsonSchema.ts
@@ -77,8 +77,9 @@ export async function openapiToTsJsonSchema(
     refHandling: 'import',
     moduleSystem: 'esm',
     idMapper: ({ id }) => id,
-    plugins: [],
     ...options,
+    // Defensive copy: prevents plugin onInit hooks from mutating the caller's plugins array
+    plugins: [...(options.plugins ?? [])],
     targets: {
       collections: options.targets.collections ?? [],
       single: options.targets.single ?? [],

--- a/src/plugins/fastifyIntegrationPlugin.ts
+++ b/src/plugins/fastifyIntegrationPlugin.ts
@@ -1,8 +1,8 @@
+import { OPEN_API_COMPONENTS_SCHEMAS_PATH } from '../constants.js';
 import type { Plugin } from '../types.js';
 import generateSchemaWith$idPlugin from './generateSchemaWith$idPlugin.js';
 
 const OUTPUT_FILE_NAME = 'fastify-integration.ts';
-const OPEN_API_COMPONENTS_SCHEMAS_PATH = '/components/schemas/';
 
 type PluginOptions = {
   schemaFilter?: (input: { id: string; isRef: boolean }) => boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,7 @@ type OnBeforeFileSave = ReturnPayload & {
 };
 
 export type Plugin<PluginOptions = void> = (options: PluginOptions) => {
+  name?: string;
   onInit?: (input: OnInitInput) => Promise<void>;
   onBeforeGeneration?: (input: OnBeforeGenerationInput) => Promise<void>;
   onBeforeSaveFile?: (input: OnBeforeFileSave) => Promise<void>;

--- a/src/utils/makeTsJsonSchema/replacePlaceholdersWithImportedSchemas.ts
+++ b/src/utils/makeTsJsonSchema/replacePlaceholdersWithImportedSchemas.ts
@@ -24,7 +24,7 @@ export function replacePlaceholdersWithImportedSchemas({
     /* v8 ignore if -- @preserve */
     if (!importedSchema) {
       throw new Error(
-        '[openapi-ts-json-schema] No matching schema found in "schemaMetaDataMap"',
+        `[openapi-ts-json-schema] No matching schema found for id "${id}" in "schemaMetaDataMap". Ensure the schema is included in "targets".`,
       );
     }
 

--- a/src/utils/refReplacementUtils.ts
+++ b/src/utils/refReplacementUtils.ts
@@ -1,7 +1,10 @@
-export const SCHEMA_ID_SYMBOL = Symbol('id');
+import {
+  SCHEMA_ID_MARKER_END,
+  SCHEMA_ID_MARKER_START,
+  SCHEMA_ID_SYMBOL,
+} from '../constants.js';
 
-const SCHEMA_ID_MARKER_START = '_OTJS-START_';
-const SCHEMA_ID_MARKER_END = '_OTJS-END_';
+export { SCHEMA_ID_SYMBOL };
 
 export const PLACEHOLDER_REGEX = new RegExp(
   `["']${SCHEMA_ID_MARKER_START}(?<id>.+)${SCHEMA_ID_MARKER_END}["']`,

--- a/src/utils/refToId.ts
+++ b/src/utils/refToId.ts
@@ -4,7 +4,9 @@
  */
 function parseRef(ref: string): string {
   if (!ref.startsWith('#/')) {
-    throw new Error(`[openapi-ts-json-schema] Unsupported ref value: "${ref}"`);
+    throw new Error(
+      `[openapi-ts-json-schema] Unsupported ref value: "${ref}". Only internal refs starting with "#/" are supported.`,
+    );
   }
 
   const refPath = ref.replace('#/', '');

--- a/test/unit-tests/refToId.test.ts
+++ b/test/unit-tests/refToId.test.ts
@@ -15,7 +15,7 @@ describe('refToId', () => {
     it('throws error', () => {
       expect(() => refToId('/components/schemas/Foo')).toThrow(
         new Error(
-          `[openapi-ts-json-schema] Unsupported ref value: "/components/schemas/Foo"`,
+          `[openapi-ts-json-schema] Unsupported ref value: "/components/schemas/Foo". Only internal refs starting with "#/" are supported.`,
         ),
       );
     });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor

## What is the new behaviour?

- Centralise internal sentinel strings and symbols (`SCHEMA_ID_MARKER_START`, `SCHEMA_ID_MARKER_END`, `SCHEMA_ID_SYMBOL`, `COMMENT_JSON_BEFORE_SYMBOL`, `OPEN_API_COMPONENTS_SCHEMAS_PATH`) in a new `src/constants.ts` module.

- Fix plugin system options mutation: `plugins` array is now shallow-copied when building internal options, preventing `onInit` hooks from mutating the caller's original array.

- Improve error messages: all thrown errors now include the offending schema id or path and a hint toward the fix.

- Plugin hook invocations are now wrapped in try/catch; errors re-thrown with the plugin name (or index) and hook name for easier debugging. Add optional `name` property to the `Plugin` return type.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
