### PR TITLE
feat: annotate circular-reference truncation with schema id

### DIFF
--- a/.changeset/violet-loops-smile.md
+++ b/.changeset/violet-loops-smile.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-json-schema': major
+---
+
+Annotate circular-reference truncation with schema id

--- a/src/utils/makeTsJsonSchema/emitTsSchema.ts
+++ b/src/utils/makeTsJsonSchema/emitTsSchema.ts
@@ -65,17 +65,20 @@ function registerImport(id: string, ctx: EmitContext): string {
 /**
  * Recursive emitter: converts a JSON-schema-shaped value into a TypeScript
  * expression string. Handles inlined-ref markers (per `refHandling`), primitives,
- * arrays, and objects. `ancestors` tracks the active parent chain so cycles can
- * be short-circuited to `{}` instead of recursing forever.
+ * arrays, and objects. `ancestorIds` tracks the active chain of id-bearing
+ * (dereferenced-ref) ancestors — those are the only nodes that can introduce
+ * cycles, since the ref-parser is what shares schema instances across the tree.
+ * When a id reappears in its own ancestor chain the recursion short-circuits
+ * with a comment that names the offending schema directly.
  */
 function emitNodeString({
   node,
   ctx,
-  ancestors,
+  ancestorIds,
 }: {
   node: unknown;
   ctx: EmitContext;
-  ancestors: Set<object>;
+  ancestorIds: Set<string>;
 }): string {
   const id = getId(node);
 
@@ -89,6 +92,18 @@ function emitNodeString({
     if (ctx.refHandling === 'keep') {
       return `{ $ref: ${JSON.stringify(ctx.idMapper({ id }))} }`;
     }
+
+    // refHandling === 'inline': only id-bearing nodes can produce cycles, so
+    // detect them here and emit the truncation annotated with the schema's
+    // own id. Preserve any leading $ref comment attached to the node.
+    if (ancestorIds.has(id)) {
+      const leading = renderLeadingComment(
+        // @ts-expect-error node is currently unknown, but the presence of an id guarantees it's a record with symbol-keyed properties
+        node,
+      );
+
+      return `{\n${leading}// Circular recursion interrupted\n}`;
+    }
   }
 
   if (
@@ -101,17 +116,15 @@ function emitNodeString({
     return JSON.stringify(node);
   }
 
-  // Cyclic occurrences collapse to "{}"
-  if (ancestors.has(node)) {
-    return '{}';
+  if (id) {
+    ancestorIds.add(id);
   }
 
-  ancestors.add(node);
   let result: string;
 
   if (Array.isArray(node)) {
     const items = node.map((value) =>
-      emitNodeString({ node: value, ctx, ancestors }),
+      emitNodeString({ node: value, ctx, ancestorIds }),
     );
     result = `[${items.join(',')}]`;
   }
@@ -121,14 +134,16 @@ function emitNodeString({
     const entries: string[] = [];
     for (const [key, value] of Object.entries(node)) {
       entries.push(
-        `${JSON.stringify(key)}: ${emitNodeString({ node: value, ctx, ancestors })}`,
+        `${JSON.stringify(key)}: ${emitNodeString({ node: value, ctx, ancestorIds })}`,
       );
     }
     const leading = renderLeadingComment(node);
     result = `{\n${leading}${entries.join(',\n')}\n}`;
   }
 
-  ancestors.delete(node);
+  if (id) {
+    ancestorIds.delete(id);
+  }
   return result;
 }
 
@@ -154,8 +169,10 @@ function renderImports(imports: Map<string, EmittedImport>): string {
  *
  * - Inlined refs marked with REFERENCED_SCHEMA_ID_SYMBOL become either identifier
  *   references (refHandling: "import") or "{ $ref: ... }" literals
- *   (refHandling: "keep"). In "inline" mode the marker is ignored.
- * - Circular nodes are emitted as "{}" (matches the prior behaviour).
+ *   (refHandling: "keep"). In "inline" mode the marker drives cycle detection.
+ * - In "inline" mode, a cycle between dereferenced schemas is short-circuited
+ *   the second time the same id appears in the active ancestor chain; the
+ *   truncation is annotated with that id.
  * - Leading comments attached via LEADING_COMMENT_SYMBOL
  *   are rendered as JS comments inside the relevant object literal.
  */
@@ -186,7 +203,11 @@ export function emitTsSchema({
   const isImportAlias =
     refHandling === 'import' && getId(rootSchema) !== undefined;
 
-  const body = emitNodeString({ node: rootSchema, ctx, ancestors: new Set() });
+  const body = emitNodeString({
+    node: rootSchema,
+    ctx,
+    ancestorIds: new Set(),
+  });
   const imports = renderImports(ctx.imports);
 
   return { body, imports, isImportAlias };

--- a/test/circularReference.test.ts
+++ b/test/circularReference.test.ts
@@ -9,7 +9,7 @@ import { fixturesPath, makeTestOutputPath } from './test-utils/index.js';
 describe('Circular reference', () => {
   describe('"refHandling" option', () => {
     describe('inline', () => {
-      it('Replaces 2nd circular reference occurrence with "{}"', async () => {
+      it('Truncates the recursion at the repeating ref-marked schema', async () => {
         const { outputPath } = await openapiToTsJsonSchema({
           openApiDocument: path.resolve(
             fixturesPath,
@@ -38,8 +38,12 @@ describe('Circular reference', () => {
               properties: {
                 previousMonth: {
                   description: 'January description',
-                  properties: {},
                   type: 'object',
+                  properties: {
+                    nextMonth: {},
+                    nextMonthTwo: {},
+                    nextMonthThree: {},
+                  },
                 },
               },
             },
@@ -49,8 +53,12 @@ describe('Circular reference', () => {
               properties: {
                 previousMonth: {
                   description: 'January description',
-                  properties: {},
                   type: 'object',
+                  properties: {
+                    nextMonth: {},
+                    nextMonthTwo: {},
+                    nextMonthThree: {},
+                  },
                 },
               },
             },
@@ -60,8 +68,12 @@ describe('Circular reference', () => {
               properties: {
                 previousMonth: {
                   description: 'January description',
-                  properties: {},
                   type: 'object',
+                  properties: {
+                    nextMonth: {},
+                    nextMonthTwo: {},
+                    nextMonthThree: {},
+                  },
                 },
               },
             },
@@ -86,19 +98,34 @@ describe('Circular reference', () => {
           // $ref: "#/components/schemas/February"
           description: "February description",
           type: "object",
-          properties: {},
+          properties: {
+            previousMonth: {
+              // $ref: "#/components/schemas/January"
+              // Circular recursion interrupted
+            },
+          },
         },
         nextMonthTwo: {
           // $ref: "#/components/schemas/February"
           description: "February description",
           type: "object",
-          properties: {},
+          properties: {
+            previousMonth: {
+              // $ref: "#/components/schemas/January"
+              // Circular recursion interrupted
+            },
+          },
         },
         nextMonthThree: {
           // $ref: "#/components/schemas/February"
           description: "February description",
           type: "object",
-          properties: {},
+          properties: {
+            previousMonth: {
+              // $ref: "#/components/schemas/January"
+              // Circular recursion interrupted
+            },
+          },
         },
       },
     },`;

--- a/test/unit-tests/emitTsSchema.test.ts
+++ b/test/unit-tests/emitTsSchema.test.ts
@@ -33,8 +33,8 @@ const baseArgs = {
 };
 
 describe('emitTsSchema', () => {
-  describe('when refHandling is "inline"', () => {
-    it('emits primitives, arrays, and nested objects as TypeScript source', () => {
+  describe('refHandling === "inline"', () => {
+    it('emits TypeScript source for primitives, arrays, and nested objects', () => {
       const result = emitTsSchema({
         rootSchema: {
           type: 'object',
@@ -69,56 +69,145 @@ describe('emitTsSchema', () => {
       });
     });
 
-    it('ignores REFERENCED_SCHEMA_ID_SYMBOL on referenced nodes', () => {
-      const inlinedRef = {
-        type: 'string',
-        [REFERENCED_SCHEMA_ID_SYMBOL]: '/components/schemas/Answer',
-      };
+    describe('on referenced nodes', () => {
+      it('ignores REFERENCED_SCHEMA_ID_SYMBOL', () => {
+        const inlinedRef = {
+          type: 'string',
+          [REFERENCED_SCHEMA_ID_SYMBOL]: '/components/schemas/Answer',
+        };
 
-      const result = emitTsSchema({
-        rootSchema: inlinedRef,
-        refHandling: 'inline',
-        schemaMetaDataMap: new Map(),
-        ...baseArgs,
-      });
+        const result = emitTsSchema({
+          rootSchema: inlinedRef,
+          refHandling: 'inline',
+          schemaMetaDataMap: new Map(),
+          ...baseArgs,
+        });
 
-      expect(result).toEqual({
-        body: ['{', '"type": "string"', '}'].join('\n'),
-        imports: '',
-        isImportAlias: false,
-      });
-    });
-
-    it('emits an empty object literal for {} without leading comments', () => {
-      const result = emitTsSchema({
-        rootSchema: {},
-        refHandling: 'inline',
-        schemaMetaDataMap: new Map(),
-        ...baseArgs,
-      });
-
-      expect(result).toEqual({
-        body: '{\n\n}',
-        imports: '',
-        isImportAlias: false,
+        expect(result).toEqual({
+          body: ['{', '"type": "string"', '}'].join('\n'),
+          imports: '',
+          isImportAlias: false,
+        });
       });
     });
 
-    it('replaces circular references with "{}"', () => {
-      const node: { name: string; self?: unknown } = { name: 'cycle' };
-      node.self = node;
+    describe('on an empty object', () => {
+      describe('no leading comment is attached', () => {
+        it('emits an empty object literal', () => {
+          const result = emitTsSchema({
+            rootSchema: {},
+            refHandling: 'inline',
+            schemaMetaDataMap: new Map(),
+            ...baseArgs,
+          });
 
-      const result = emitTsSchema({
-        rootSchema: node,
-        refHandling: 'inline',
-        schemaMetaDataMap: new Map(),
-        ...baseArgs,
+          expect(result).toEqual({
+            body: '{\n\n}',
+            imports: '',
+            isImportAlias: false,
+          });
+        });
+      });
+    });
+
+    describe('on circular references between dereferenced schemas', () => {
+      it('truncates the second occurrence of an id-marked node and annotates it with that id', () => {
+        const node: {
+          name: string;
+          self?: unknown;
+          [REFERENCED_SCHEMA_ID_SYMBOL]: string;
+        } = {
+          name: 'cycle',
+          [REFERENCED_SCHEMA_ID_SYMBOL]: '/components/schemas/Foo',
+        };
+        node.self = node;
+
+        const result = emitTsSchema({
+          rootSchema: node,
+          refHandling: 'inline',
+          schemaMetaDataMap: new Map(),
+          ...baseArgs,
+        });
+
+        expect(result).toEqual({
+          body: [
+            '{',
+            '"name": "cycle",',
+            '"self": {',
+            '// Circular recursion interrupted',
+            '}',
+            '}',
+          ].join('\n'),
+          imports: '',
+          isImportAlias: false,
+        });
       });
 
-      expect(result).toEqual({
-        body: ['{', '"name": "cycle",', '"self": {}', '}'].join('\n'),
-        imports: '',
-        isImportAlias: false,
+      it('preserves a leading comment on the truncated node', () => {
+        const node: {
+          name: string;
+          self?: unknown;
+          [REFERENCED_SCHEMA_ID_SYMBOL]: string;
+          [LEADING_COMMENT_SYMBOL]: string;
+        } = {
+          name: 'cycle',
+          [REFERENCED_SCHEMA_ID_SYMBOL]: '/components/schemas/Foo',
+          [LEADING_COMMENT_SYMBOL]: ' $ref: "#/components/schemas/Foo"',
+        };
+        node.self = node;
+
+        const result = emitTsSchema({
+          rootSchema: node,
+          refHandling: 'inline',
+          schemaMetaDataMap: new Map(),
+          ...baseArgs,
+        });
+
+        expect(result).toEqual({
+          body: [
+            '{',
+            '// $ref: "#/components/schemas/Foo"',
+            '"name": "cycle",',
+            '"self": {',
+            '// $ref: "#/components/schemas/Foo"',
+            '// Circular recursion interrupted',
+            '}',
+            '}',
+          ].join('\n'),
+          imports: '',
+          isImportAlias: false,
+        });
+      });
+
+      it('treats sibling occurrences of the same id as independent (no false cycle)', () => {
+        const shared = {
+          type: 'string',
+          [REFERENCED_SCHEMA_ID_SYMBOL]: '/components/schemas/Shared',
+        };
+
+        const result = emitTsSchema({
+          rootSchema: { properties: { a: shared, b: shared } },
+          refHandling: 'inline',
+          schemaMetaDataMap: new Map(),
+          ...baseArgs,
+        });
+
+        expect(result).toEqual({
+          body: [
+            '{',
+            '"properties": {',
+            '"a": {',
+            '"type": "string"',
+            '},',
+            '"b": {',
+            '"type": "string"',
+            '}',
+            '}',
+            '}',
+          ].join('\n'),
+          imports: '',
+          isImportAlias: false,
+        });
       });
     });
 
@@ -151,63 +240,67 @@ describe('emitTsSchema', () => {
   });
 
   describe('refHandling === "import"', () => {
-    it('replaces marked nodes with imported identifiers and registers imports', () => {
-      const schemaMetaDataMap: SchemaMetaDataMap = new Map();
-      schemaMetaDataMap.set(
-        '/components/schemas/Answer',
-        makeMeta({
-          id: '/components/schemas/Answer',
-          uniqueName: 'componentsSchemasAnswer',
-          absoluteImportPath: path.resolve('/out/components/schemas/Answer'),
-        }),
-      );
-      schemaMetaDataMap.set(
-        '/components/schemas/Question',
-        makeMeta({
-          id: '/components/schemas/Question',
-          uniqueName: 'componentsSchemasQuestion',
-          absoluteImportPath: path.resolve('/out/components/schemas/Question'),
-        }),
-      );
+    describe('on marked nodes', () => {
+      it('replaces them with imported identifiers and registers imports', () => {
+        const schemaMetaDataMap: SchemaMetaDataMap = new Map();
+        schemaMetaDataMap.set(
+          '/components/schemas/Answer',
+          makeMeta({
+            id: '/components/schemas/Answer',
+            uniqueName: 'componentsSchemasAnswer',
+            absoluteImportPath: path.resolve('/out/components/schemas/Answer'),
+          }),
+        );
+        schemaMetaDataMap.set(
+          '/components/schemas/Question',
+          makeMeta({
+            id: '/components/schemas/Question',
+            uniqueName: 'componentsSchemasQuestion',
+            absoluteImportPath: path.resolve(
+              '/out/components/schemas/Question',
+            ),
+          }),
+        );
 
-      const answerRef = {
-        type: 'string',
-        [REFERENCED_SCHEMA_ID_SYMBOL]: '/components/schemas/Answer',
-      };
-      const questionRef = {
-        type: 'string',
-        [REFERENCED_SCHEMA_ID_SYMBOL]: '/components/schemas/Question',
-      };
+        const answerRef = {
+          type: 'string',
+          [REFERENCED_SCHEMA_ID_SYMBOL]: '/components/schemas/Answer',
+        };
+        const questionRef = {
+          type: 'string',
+          [REFERENCED_SCHEMA_ID_SYMBOL]: '/components/schemas/Question',
+        };
 
-      const result = emitTsSchema({
-        rootSchema: {
-          properties: { a: answerRef, b: questionRef, c: answerRef },
-        },
-        refHandling: 'import',
-        schemaMetaDataMap,
-        ...baseArgs,
-      });
+        const result = emitTsSchema({
+          rootSchema: {
+            properties: { a: answerRef, b: questionRef, c: answerRef },
+          },
+          refHandling: 'import',
+          schemaMetaDataMap,
+          ...baseArgs,
+        });
 
-      expect(result).toEqual({
-        body: [
-          '{',
-          '"properties": {',
-          '"a": componentsSchemasAnswer,',
-          '"b": componentsSchemasQuestion,',
-          '"c": componentsSchemasAnswer',
-          '}',
-          '}',
-        ].join('\n'),
-        imports: [
-          'import componentsSchemasQuestion from "./Question.js"',
-          'import componentsSchemasAnswer from "./Answer.js"',
-          '',
-        ].join('\n'),
-        isImportAlias: false,
+        expect(result).toEqual({
+          body: [
+            '{',
+            '"properties": {',
+            '"a": componentsSchemasAnswer,',
+            '"b": componentsSchemasQuestion,',
+            '"c": componentsSchemasAnswer',
+            '}',
+            '}',
+          ].join('\n'),
+          imports: [
+            'import componentsSchemasQuestion from "./Question.js"',
+            'import componentsSchemasAnswer from "./Answer.js"',
+            '',
+          ].join('\n'),
+          isImportAlias: false,
+        });
       });
     });
 
-    describe('and the root schema is itself a marked reference', () => {
+    describe('the root schema is itself a marked reference', () => {
       it('flags the result as an import alias', () => {
         const schemaMetaDataMap: SchemaMetaDataMap = new Map();
         schemaMetaDataMap.set(
@@ -239,31 +332,33 @@ describe('emitTsSchema', () => {
   });
 
   describe('refHandling === "keep"', () => {
-    it('emits "{ $ref: ... }" object literals at marked nodes', () => {
-      const schemaMetaDataMap: SchemaMetaDataMap = new Map();
-      const inlinedRef = {
-        type: 'string',
-        [REFERENCED_SCHEMA_ID_SYMBOL]: '/components/schemas/Answer',
-      };
+    describe('on marked nodes', () => {
+      it('emits "{ $ref: ... }" object literals', () => {
+        const schemaMetaDataMap: SchemaMetaDataMap = new Map();
+        const inlinedRef = {
+          type: 'string',
+          [REFERENCED_SCHEMA_ID_SYMBOL]: '/components/schemas/Answer',
+        };
 
-      const result = emitTsSchema({
-        rootSchema: { properties: { a: inlinedRef } },
-        refHandling: 'keep',
-        schemaMetaDataMap,
-        ...baseArgs,
-        idMapper: ({ id }) => `#${id}`,
-      });
+        const result = emitTsSchema({
+          rootSchema: { properties: { a: inlinedRef } },
+          refHandling: 'keep',
+          schemaMetaDataMap,
+          ...baseArgs,
+          idMapper: ({ id }) => `#${id}`,
+        });
 
-      expect(result).toEqual({
-        body: [
-          '{',
-          '"properties": {',
-          '"a": { $ref: "#/components/schemas/Answer" }',
-          '}',
-          '}',
-        ].join('\n'),
-        imports: '',
-        isImportAlias: false,
+        expect(result).toEqual({
+          body: [
+            '{',
+            '"properties": {',
+            '"a": { $ref: "#/components/schemas/Answer" }',
+            '}',
+            '}',
+          ].join('\n'),
+          imports: '',
+          isImportAlias: false,
+        });
       });
     });
   });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the new behaviour?

When emitTsSchema short-circuits a cycle it now emits a JS comment naming the closest identified ancestor schema instead of a bare `{}`, making the generated output self-documenting.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
