### PR TITLE
docs: explain TypeScript JSON import limitation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ These schemas:
 
 In short: **OpenAPI spec becomes the single source of truth** for both runtime validation and TypeScript typing.
 
+> [!IMPORTANT]
+> **Why a code generator and not just a JSON import?**
+>
+> The whole reason this library exists is that **TypeScript cannot import a `.json` file as `const`** ([microsoft/TypeScript#32063](https://github.com/microsoft/TypeScript/issues/32063)). Imported JSON is widened to its base types (`string`, `number`, …), which destroys the literal information `json-schema-to-ts` needs to infer types from a schema.
+>
+> The workaround is to emit `.ts` modules with an `as const` assertion — exactly what `openapi-ts-json-schema` does. If TypeScript ever supports `import schema from './schema.json' as const`, most use cases for this library go away and you can consume your OpenAPI-derived JSON Schemas directly.
+
 ## Example
 
 From this OpenAPI definition:


### PR DESCRIPTION
Why: clarifies that this library exists because TypeScript cannot import JSON files as const, and would be largely unnecessary if that limitation were ever lifted.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behaviour?

You can also link to an open issue here.

## What is the new behaviour?

...

## Does this PR introduce a breaking change?

What changes might users need to make in their application due to this PR?

## Other information:

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
