### PR TITLE
feat: validate targets shape

### DIFF
--- a/.changeset/validate-targets-shape.md
+++ b/.changeset/validate-targets-shape.md
@@ -1,0 +1,14 @@
+---
+'openapi-ts-json-schema': major
+---
+
+Validate the shape of `targets.single` and `targets.collections` entries
+
+Each target path is now checked against the bundled OpenAPI document and rejected with a clear error when the resolved value cannot be processed. This catches typos and misuse that previously produced nonsensical output files.
+
+**BREAKING CHANGE** — invocations that previously emitted incorrect files now throw. The new validations are:
+
+- A `single` or `collections` target that resolves to a primitive or array throws `"targets.<kind>" target "<path>" must resolve to an object, got <type>`.
+- A `collections` target whose direct children are not all objects (e.g. a leaf schema like `components.schemas.User` passed as a collection) throws `"targets.collections" target "<path>" must be a record of definition objects, but child "<key>" is <type>. Did you mean to use "targets.single"?`.
+
+The pre-existing `target not found in OAS definition` error is unchanged.

--- a/.changeset/validate-targets-shape.md
+++ b/.changeset/validate-targets-shape.md
@@ -8,7 +8,5 @@ Each target path is now checked against the bundled OpenAPI document and rejecte
 
 **BREAKING CHANGE** — invocations that previously emitted incorrect files now throw. The new validations are:
 
-- A `single` or `collections` target that resolves to a primitive or array throws `"targets.<kind>" target "<path>" must resolve to an object, got <type>`.
-- A `collections` target whose direct children are not all objects (e.g. a leaf schema like `components.schemas.User` passed as a collection) throws `"targets.collections" target "<path>" must be a record of definition objects, but child "<key>" is <type>. Did you mean to use "targets.single"?`.
-
-The pre-existing `target not found in OAS definition` error is unchanged.
+- A `single` or `collections` target that does not resolve to an object (missing path, primitive, or array) throws `"targets.<kind>" target "<path>" must resolve to an object.` This replaces the previous `target not found in OAS definition` error.
+- A `collections` target whose direct children are not all objects (e.g. a leaf schema like `components.schemas.User` passed as a collection) throws `"targets.collections" target "<path>" must be a record of definition objects, but child "<key>" is not an object. Did you mean to use "targets.single"?`.

--- a/src/openapiToTsJsonSchema.ts
+++ b/src/openapiToTsJsonSchema.ts
@@ -29,6 +29,7 @@ import {
   refToId,
   saveFile,
   saveSchemaFiles,
+  validateTargets,
 } from './utils/index.js';
 
 /**
@@ -138,6 +139,8 @@ export async function openapiToTsJsonSchema(
   const bundledOpenApiDocument: OpenApiDocument =
     await openApiParser.bundle(openApiDocumentPath);
 
+  validateTargets({ document: bundledOpenApiDocument, targets });
+
   // Convert oas definitions to JSON schema (excluding paths and parameter objects)
   const openApiDocumentWithJsonSchemaDefinitions =
     convertOpenApiDocumentDefinitionsToJsonSchema(bundledOpenApiDocument);
@@ -201,12 +204,6 @@ export async function openapiToTsJsonSchema(
     const jsonSchemaDefinition = get(jsonSchema, path);
     const openApiDefinition = get(bundledOpenApiDocument, path);
 
-    if (!openApiDefinition) {
-      throw new Error(
-        `[openapi-ts-json-schema] target not found in OAS definition: "${path}". Check that the path exists in your OpenAPI document.`,
-      );
-    }
-
     // Handle single definition path
     const { schemaName, schemaRelativeDirName } = parseSingleItemPath(path);
     const id = makeId({
@@ -229,12 +226,6 @@ export async function openapiToTsJsonSchema(
   for (const path of targets.collections) {
     const jsonSchemaDefinitions = get(jsonSchema, path);
     const openApiDefinitions = get(bundledOpenApiDocument, path);
-
-    if (!openApiDefinitions) {
-      throw new Error(
-        `[openapi-ts-json-schema] target not found in OAS definition: "${path}". Check that the path exists in your OpenAPI document.`,
-      );
-    }
 
     // Handle collection definition path
     for (const schemaName in jsonSchemaDefinitions) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,6 +15,7 @@ export { filenamify } from './filenamify.js';
 export { makeUniqueName } from './makeUniqueName.js';
 export { isOpenApiParameterObject } from './isOpenApiParameterObject.js';
 export { parseSingleItemPath } from './parseSingleItemPath.js';
+export { validateTargets } from './validateTargets.js';
 
 export { clearFolder } from './clearFolder.js';
 export { makeRelativeImportPath } from './makeRelativeImportPath.js';

--- a/src/utils/validateTargets.ts
+++ b/src/utils/validateTargets.ts
@@ -1,0 +1,68 @@
+import get from 'lodash.get';
+
+import type { OpenApiDocument } from '../types.js';
+import { isObject } from './isObject.js';
+
+function describeValue(value: unknown): string {
+  if (Array.isArray(value)) return 'an array';
+  if (value === null) return 'null';
+  return `a ${typeof value}`;
+}
+
+/**
+ * Validate that `targets.single` and `targets.collections` resolve to
+ * shapes the generator can handle.
+ *
+ * - Throws "target not found" if a path resolves to `undefined` or `null`.
+ * - Throws if a target resolves to a non-object (primitive or array).
+ * - Throws if a `collections` target resolves to a record whose direct
+ *   children are not all objects (catches passing a leaf schema where a
+ *   record-of-schemas is expected).
+ */
+export function validateTargets({
+  document,
+  targets,
+}: {
+  document: OpenApiDocument;
+  targets: { single: string[]; collections: string[] };
+}): void {
+  for (const targetPath of targets.single) {
+    const value = get(document, targetPath);
+
+    if (!value) {
+      throw new Error(
+        `[openapi-ts-json-schema] target not found in OAS definition: "${targetPath}". Check that the path exists in your OpenAPI document.`,
+      );
+    }
+
+    if (!isObject(value)) {
+      throw new Error(
+        `[openapi-ts-json-schema] "targets.single" target "${targetPath}" must resolve to an object, got ${describeValue(value)}.`,
+      );
+    }
+  }
+
+  for (const targetPath of targets.collections) {
+    const value = get(document, targetPath);
+
+    if (!value) {
+      throw new Error(
+        `[openapi-ts-json-schema] target not found in OAS definition: "${targetPath}". Check that the path exists in your OpenAPI document.`,
+      );
+    }
+
+    if (!isObject(value)) {
+      throw new Error(
+        `[openapi-ts-json-schema] "targets.collections" target "${targetPath}" must resolve to an object, got ${describeValue(value)}.`,
+      );
+    }
+
+    for (const [childKey, childValue] of Object.entries(value)) {
+      if (!isObject(childValue)) {
+        throw new Error(
+          `[openapi-ts-json-schema] "targets.collections" target "${targetPath}" must be a record of definition objects, but child "${childKey}" is ${describeValue(childValue)}. Did you mean to use "targets.single"?`,
+        );
+      }
+    }
+  }
+}

--- a/src/utils/validateTargets.ts
+++ b/src/utils/validateTargets.ts
@@ -3,18 +3,11 @@ import get from 'lodash.get';
 import type { OpenApiDocument } from '../types.js';
 import { isObject } from './isObject.js';
 
-function describeValue(value: unknown): string {
-  if (Array.isArray(value)) return 'an array';
-  if (value === null) return 'null';
-  return `a ${typeof value}`;
-}
-
 /**
  * Validate that `targets.single` and `targets.collections` resolve to
  * shapes the generator can handle.
  *
- * - Throws "target not found" if a path resolves to `undefined` or `null`.
- * - Throws if a target resolves to a non-object (primitive or array).
+ * - Throws if a target path does not resolve to an object.
  * - Throws if a `collections` target resolves to a record whose direct
  *   children are not all objects (catches passing a leaf schema where a
  *   record-of-schemas is expected).
@@ -29,15 +22,9 @@ export function validateTargets({
   for (const targetPath of targets.single) {
     const value = get(document, targetPath);
 
-    if (!value) {
-      throw new Error(
-        `[openapi-ts-json-schema] target not found in OAS definition: "${targetPath}". Check that the path exists in your OpenAPI document.`,
-      );
-    }
-
     if (!isObject(value)) {
       throw new Error(
-        `[openapi-ts-json-schema] "targets.single" target "${targetPath}" must resolve to an object, got ${describeValue(value)}.`,
+        `[openapi-ts-json-schema] "targets.single" target "${targetPath}" must resolve to an object.`,
       );
     }
   }
@@ -45,22 +32,16 @@ export function validateTargets({
   for (const targetPath of targets.collections) {
     const value = get(document, targetPath);
 
-    if (!value) {
-      throw new Error(
-        `[openapi-ts-json-schema] target not found in OAS definition: "${targetPath}". Check that the path exists in your OpenAPI document.`,
-      );
-    }
-
     if (!isObject(value)) {
       throw new Error(
-        `[openapi-ts-json-schema] "targets.collections" target "${targetPath}" must resolve to an object, got ${describeValue(value)}.`,
+        `[openapi-ts-json-schema] "targets.collections" target "${targetPath}" must resolve to an object.`,
       );
     }
 
     for (const [childKey, childValue] of Object.entries(value)) {
       if (!isObject(childValue)) {
         throw new Error(
-          `[openapi-ts-json-schema] "targets.collections" target "${targetPath}" must be a record of definition objects, but child "${childKey}" is ${describeValue(childValue)}. Did you mean to use "targets.single"?`,
+          `[openapi-ts-json-schema] "targets.collections" target "${targetPath}" must be a record of definition objects, but child "${childKey}" is not an object. Did you mean to use "targets.single"?`,
         );
       }
     }

--- a/test/targets.test.ts
+++ b/test/targets.test.ts
@@ -86,6 +86,23 @@ describe('targets option', () => {
         );
       });
     });
+
+    describe('path resolves to a primitive', () => {
+      it('throws expected error', async () => {
+        await expect(
+          openapiToTsJsonSchema({
+            openApiDocument: path.resolve(fixturesPath, 'complex/specs.yaml'),
+            outputPath: makeTestOutputPath('targets-single-primitive'),
+            targets: {
+              single: ['info.title'],
+            },
+            silent: true,
+          }),
+        ).rejects.toThrow(
+          '[openapi-ts-json-schema] "targets.single" target "info.title" must resolve to an object, got a string.',
+        );
+      });
+    });
   });
 
   describe('targets.collections[]', () => {
@@ -141,6 +158,40 @@ describe('targets option', () => {
           }),
         ).rejects.toThrow(
           '[openapi-ts-json-schema] target not found in OAS definition: "non-existing-path"',
+        );
+      });
+    });
+
+    describe('path resolves to a leaf schema', () => {
+      it('throws with "did you mean single" hint', async () => {
+        await expect(
+          openapiToTsJsonSchema({
+            openApiDocument: path.resolve(fixturesPath, 'complex/specs.yaml'),
+            outputPath: makeTestOutputPath('targets-collections-leaf-schema'),
+            targets: {
+              collections: ['components.schemas.January'],
+            },
+            silent: true,
+          }),
+        ).rejects.toThrow(
+          '[openapi-ts-json-schema] "targets.collections" target "components.schemas.January" must be a record of definition objects, but child "description" is a string. Did you mean to use "targets.single"?',
+        );
+      });
+    });
+
+    describe('path resolves to a primitive', () => {
+      it('throws expected error', async () => {
+        await expect(
+          openapiToTsJsonSchema({
+            openApiDocument: path.resolve(fixturesPath, 'complex/specs.yaml'),
+            outputPath: makeTestOutputPath('targets-collections-primitive'),
+            targets: {
+              collections: ['info.title'],
+            },
+            silent: true,
+          }),
+        ).rejects.toThrow(
+          '[openapi-ts-json-schema] "targets.collections" target "info.title" must resolve to an object, got a string.',
         );
       });
     });

--- a/test/targets.test.ts
+++ b/test/targets.test.ts
@@ -82,7 +82,7 @@ describe('targets option', () => {
             silent: true,
           }),
         ).rejects.toThrow(
-          '[openapi-ts-json-schema] target not found in OAS definition: "paths./non-existing-path"',
+          '[openapi-ts-json-schema] "targets.single" target "paths./non-existing-path" must resolve to an object.',
         );
       });
     });
@@ -99,7 +99,7 @@ describe('targets option', () => {
             silent: true,
           }),
         ).rejects.toThrow(
-          '[openapi-ts-json-schema] "targets.single" target "info.title" must resolve to an object, got a string.',
+          '[openapi-ts-json-schema] "targets.single" target "info.title" must resolve to an object.',
         );
       });
     });
@@ -118,7 +118,7 @@ describe('targets option', () => {
             silent: true,
           }),
         ).rejects.toThrow(
-          '[openapi-ts-json-schema] target not found in OAS definition: "components.schemas."',
+          '[openapi-ts-json-schema] "targets.collections" target "components.schemas." must resolve to an object.',
         );
       });
     });
@@ -157,7 +157,7 @@ describe('targets option', () => {
             silent: true,
           }),
         ).rejects.toThrow(
-          '[openapi-ts-json-schema] target not found in OAS definition: "non-existing-path"',
+          '[openapi-ts-json-schema] "targets.collections" target "non-existing-path" must resolve to an object.',
         );
       });
     });
@@ -174,7 +174,7 @@ describe('targets option', () => {
             silent: true,
           }),
         ).rejects.toThrow(
-          '[openapi-ts-json-schema] "targets.collections" target "components.schemas.January" must be a record of definition objects, but child "description" is a string. Did you mean to use "targets.single"?',
+          '[openapi-ts-json-schema] "targets.collections" target "components.schemas.January" must be a record of definition objects, but child "description" is not an object. Did you mean to use "targets.single"?',
         );
       });
     });
@@ -191,7 +191,7 @@ describe('targets option', () => {
             silent: true,
           }),
         ).rejects.toThrow(
-          '[openapi-ts-json-schema] "targets.collections" target "info.title" must resolve to an object, got a string.',
+          '[openapi-ts-json-schema] "targets.collections" target "info.title" must resolve to an object.',
         );
       });
     });

--- a/test/unit-tests/validateTargets.test.ts
+++ b/test/unit-tests/validateTargets.test.ts
@@ -77,7 +77,7 @@ describe('validateTargets util', () => {
           targets: { single: ['components.schemas.NotThere'], collections: [] },
         }),
       ).toThrow(
-        '[openapi-ts-json-schema] target not found in OAS definition: "components.schemas.NotThere". Check that the path exists in your OpenAPI document.',
+        '[openapi-ts-json-schema] "targets.single" target "components.schemas.NotThere" must resolve to an object.',
       );
     });
 
@@ -88,7 +88,7 @@ describe('validateTargets util', () => {
           targets: { single: ['info.title'], collections: [] },
         }),
       ).toThrow(
-        '[openapi-ts-json-schema] "targets.single" target "info.title" must resolve to an object, got a string.',
+        '[openapi-ts-json-schema] "targets.single" target "info.title" must resolve to an object.',
       );
     });
 
@@ -99,7 +99,7 @@ describe('validateTargets util', () => {
           targets: { single: ['servers'], collections: [] },
         }),
       ).toThrow(
-        '[openapi-ts-json-schema] "targets.single" target "servers" must resolve to an object, got an array.',
+        '[openapi-ts-json-schema] "targets.single" target "servers" must resolve to an object.',
       );
     });
   });
@@ -112,7 +112,7 @@ describe('validateTargets util', () => {
           targets: { single: [], collections: ['not.a.real.path'] },
         }),
       ).toThrow(
-        '[openapi-ts-json-schema] target not found in OAS definition: "not.a.real.path". Check that the path exists in your OpenAPI document.',
+        '[openapi-ts-json-schema] "targets.collections" target "not.a.real.path" must resolve to an object.',
       );
     });
 
@@ -123,7 +123,7 @@ describe('validateTargets util', () => {
           targets: { single: [], collections: ['info.title'] },
         }),
       ).toThrow(
-        '[openapi-ts-json-schema] "targets.collections" target "info.title" must resolve to an object, got a string.',
+        '[openapi-ts-json-schema] "targets.collections" target "info.title" must resolve to an object.',
       );
     });
 
@@ -137,7 +137,7 @@ describe('validateTargets util', () => {
           },
         }),
       ).toThrow(
-        '[openapi-ts-json-schema] "targets.collections" target "components.schemas.January" must be a record of definition objects, but child "type" is a string. Did you mean to use "targets.single"?',
+        '[openapi-ts-json-schema] "targets.collections" target "components.schemas.January" must be a record of definition objects, but child "type" is not an object. Did you mean to use "targets.single"?',
       );
     });
   });

--- a/test/unit-tests/validateTargets.test.ts
+++ b/test/unit-tests/validateTargets.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+
+import type { OpenApiDocument } from '../../src/types.js';
+import { validateTargets } from '../../src/utils/validateTargets.js';
+
+const document: OpenApiDocument = {
+  openapi: '3.0.3',
+  info: { title: 'title', version: '1.0.0' },
+  servers: [{ url: 'https://example.com' }],
+  components: {
+    schemas: {
+      January: {
+        type: 'object',
+        required: ['isJanuary'],
+        properties: { isJanuary: { type: 'boolean' } },
+      },
+      February: {
+        type: 'object',
+        properties: { isFebruary: { type: 'boolean' } },
+      },
+    },
+  },
+  paths: {
+    '/v1/path-1': {
+      get: { responses: { '200': { description: 'ok' } } },
+    },
+  },
+};
+
+describe('validateTargets util', () => {
+  describe('valid targets', () => {
+    it('passes for a record-of-schemas as collection', () => {
+      expect(() =>
+        validateTargets({
+          document,
+          targets: { single: [], collections: ['components.schemas'] },
+        }),
+      ).not.toThrow();
+    });
+
+    it('passes for a leaf schema as single', () => {
+      expect(() =>
+        validateTargets({
+          document,
+          targets: {
+            single: ['components.schemas.January'],
+            collections: [],
+          },
+        }),
+      ).not.toThrow();
+    });
+
+    it('passes for a path item as single', () => {
+      expect(() =>
+        validateTargets({
+          document,
+          targets: { single: ['paths./v1/path-1'], collections: [] },
+        }),
+      ).not.toThrow();
+    });
+
+    it('passes when both targets lists are empty', () => {
+      expect(() =>
+        validateTargets({
+          document,
+          targets: { single: [], collections: [] },
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe('targets.single', () => {
+    it('throws on non-existing path', () => {
+      expect(() =>
+        validateTargets({
+          document,
+          targets: { single: ['components.schemas.NotThere'], collections: [] },
+        }),
+      ).toThrow(
+        '[openapi-ts-json-schema] target not found in OAS definition: "components.schemas.NotThere". Check that the path exists in your OpenAPI document.',
+      );
+    });
+
+    it('throws when resolving to a primitive', () => {
+      expect(() =>
+        validateTargets({
+          document,
+          targets: { single: ['info.title'], collections: [] },
+        }),
+      ).toThrow(
+        '[openapi-ts-json-schema] "targets.single" target "info.title" must resolve to an object, got a string.',
+      );
+    });
+
+    it('throws when resolving to an array', () => {
+      expect(() =>
+        validateTargets({
+          document,
+          targets: { single: ['servers'], collections: [] },
+        }),
+      ).toThrow(
+        '[openapi-ts-json-schema] "targets.single" target "servers" must resolve to an object, got an array.',
+      );
+    });
+  });
+
+  describe('targets.collections', () => {
+    it('throws on non-existing path', () => {
+      expect(() =>
+        validateTargets({
+          document,
+          targets: { single: [], collections: ['not.a.real.path'] },
+        }),
+      ).toThrow(
+        '[openapi-ts-json-schema] target not found in OAS definition: "not.a.real.path". Check that the path exists in your OpenAPI document.',
+      );
+    });
+
+    it('throws when resolving to a primitive', () => {
+      expect(() =>
+        validateTargets({
+          document,
+          targets: { single: [], collections: ['info.title'] },
+        }),
+      ).toThrow(
+        '[openapi-ts-json-schema] "targets.collections" target "info.title" must resolve to an object, got a string.',
+      );
+    });
+
+    it('throws when resolving to a leaf schema (non-object child)', () => {
+      expect(() =>
+        validateTargets({
+          document,
+          targets: {
+            single: [],
+            collections: ['components.schemas.January'],
+          },
+        }),
+      ).toThrow(
+        '[openapi-ts-json-schema] "targets.collections" target "components.schemas.January" must be a record of definition objects, but child "type" is a string. Did you mean to use "targets.single"?',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behaviour?

Non existing `targets` silently fail

## What is the new behaviour?

Throw error on non-existing `targets`

## Does this PR introduce a breaking change?

Yes

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
