### PR TITLE
test: cover Xquik search schema output

### DIFF
--- a/test/fixtures/xquik-search/specs.yaml
+++ b/test/fixtures/xquik-search/specs.yaml
@@ -1,0 +1,53 @@
+openapi: 3.0.3
+info:
+  title: Xquik API
+  version: 1.0.0
+servers:
+  - url: https://xquik.com
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: x-api-key
+paths:
+  /api/v1/x/tweets/search:
+    get:
+      operationId: searchTweets
+      security:
+        - apiKey: []
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        '200':
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - text
+                      properties:
+                        id:
+                          type: string
+                        text:
+                          type: string

--- a/test/xquik-search.test.ts
+++ b/test/xquik-search.test.ts
@@ -1,0 +1,81 @@
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import { openapiToTsJsonSchema } from '../src/index.js';
+import { fixturesPath, makeTestOutputPath } from './test-utils/index.js';
+
+describe('Xquik search OpenAPI input', () => {
+  it('generates path schemas for search query parameters and responses', async () => {
+    const { outputPath } = await openapiToTsJsonSchema({
+      openApiDocument: path.resolve(fixturesPath, 'xquik-search/specs.yaml'),
+      outputPath: makeTestOutputPath('xquik-search'),
+      targets: {
+        collections: ['paths'],
+      },
+      refHandling: 'import',
+      silent: true,
+    });
+
+    const searchPathSchema = await import(
+      path.resolve(outputPath, 'paths/_api_v1_x_tweets_search')
+    );
+
+    expect(searchPathSchema.default).toEqual({
+      get: {
+        operationId: 'searchTweets',
+        parameters: {
+          query: {
+            type: 'object',
+            properties: {
+              q: {
+                type: 'string',
+              },
+              limit: {
+                type: 'integer',
+                minimum: 1,
+                maximum: 100,
+              },
+            },
+            required: ['q'],
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Search results',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['data'],
+                  properties: {
+                    data: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        required: ['id', 'text'],
+                        properties: {
+                          id: {
+                            type: 'string',
+                          },
+                          text: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        security: [
+          {
+            apiKey: [],
+          },
+        ],
+      },
+    });
+  });
+});


### PR DESCRIPTION
Summary
- Adds a compact Xquik search OpenAPI fixture.
- Verifies path schema generation for query parameters, responses, operationId, and security metadata.

Validation
- source check passed.
- Focused Vitest test passed.